### PR TITLE
BODS-7167 Script the deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,3 +246,23 @@ jobs:
             --tags "BuiltFrom=${VERSION} ProjectName=${{ vars.PROJECT_NAME }} Environment=${RC_ENV}"
 
           echo "[INFO] Application component (BACKEND) with version ${VERSION} successfully deployed into ${RC_ENV^^}"
+
+  create-pull-request:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        if: contains(fromJSON('["refs/heads/sandbox", "refs/heads/dev", "refs/heads/test"]'), github.ref)
+        with:
+          script: |
+            const branchName = context.ref.split("/").pop()
+            const nextBranch = {"sandbox": "dev", "dev": "test", "test": "main"}[branchName]
+            const result = await github.rest.pulls.create({
+              title: `${branchName} -> ${nextBranch}`,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: branchName,
+              base: nextBranch,
+              body: `This PR was auto-generated after a successful deployment of the ${branchName} branch. Once approved, it will be automatically merged with the correct merge strategy.`
+            });

--- a/.github/workflows/merge-deployment-pr.yml
+++ b/.github/workflows/merge-deployment-pr.yml
@@ -1,0 +1,28 @@
+name: Merge deployment pull request
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  id-token: write
+
+jobs:
+  merge-deployment-pr:
+    if: github.event.review.state == 'approved' && contains(fromJSON('["dev", "test", "main"]'), github.event.pull_request.base.ref)
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: merge
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        
+        git fetch
+        git checkout ${{ github.event.pull_request.base.ref }}
+        git reset ${{ github.sha }}
+        git push


### PR DESCRIPTION
Adds a workflow for doing a fast forward merge when a PR to dev/test/main is approved. 
A new job on the deployment workflow for creating those PRs when a deployment to sandbox/dev/test completes successfully