### PR TITLE
Leave external data as dictionaries

### DIFF
--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/app.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/app.py
@@ -120,7 +120,7 @@ def historic_record_handler(rec: SQSRecord, shards: OperatorShards) -> None:
         logger.info("Fetching AVL data")
         avl_list = s3_client.get_avl_data(fname)
         avl_list = filter_avl_list(shard_identifier, shards, avl_list)
-        batch_id = avl_list[0].batch_id  # assuming we have at least one AVL
+        batch_id = avl_list[0]["batch_id"]  # assuming we have at least one AVL
     except Exception:
         logger.exception("An error occurred when processing historic record")
         return
@@ -153,7 +153,7 @@ def historic_record_handler(rec: SQSRecord, shards: OperatorShards) -> None:
 
 def validate_avl_list(avl_list: Sequence[AVLRecord], expected_batch_id: int) -> None:
     for avl in avl_list:
-        if avl.batch_id != expected_batch_id:
+        if avl["batch_id"] != expected_batch_id:
             raise Exception("AVLs with multiple match ids retrieved")  # noqa: TRY002 - Not worth making an exception type
 
 

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_s3.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_s3.py
@@ -13,26 +13,16 @@ from aws_lambda_powertools import Logger
 from botocore.exceptions import ClientError
 from pandas import DataFrame
 
-from .matcher.models import AVLRecord, OperatorShards, StopDetails, Timetable
+from .matcher.models import (
+    AVLRecord,
+    OperatorShards,
+    Timetable,
+    avl_data_type,
+)
 from .matcher.utils import timer
 
 logger = Logger()
 client = boto3.client("s3")
-
-
-def parse_timetable(timetable: dict[str, dict[str, list]]) -> Timetable:
-    parsed = {}
-    for group_id, route in timetable.items():
-        parsed[group_id] = {}
-        for key, value in route.items():
-            parsed[group_id][key] = StopDetails(
-                latitude=value[0][0],
-                longitude=value[0][1],
-                expected_time=value[1],
-                timetable_id=value[2],
-                date=value[3],
-            )
-    return parsed
 
 
 class TimetableS3Client:
@@ -91,8 +81,7 @@ class TimetableS3Client:
 
     def download_timetable(self, key: str) -> Timetable:
         """Download Timetable Data"""
-        data = self._get_from_s3(key)
-        return parse_timetable(data)
+        return self._get_from_s3(key)
 
     @timer(logger)
     def get_shards(self) -> OperatorShards:
@@ -162,25 +151,12 @@ class TimetableS3Client:
             number_of_files=len(filename),
         )
         start_time = time.time()
-        data_type = {
-            "recorded_at_time": str,
-            "response_timestamp": str,
-            "latitude": float,
-            "longitude": float,
-            "line_name": str,
-            "operator_ref": str,
-            "vehicle_ref": str,
-            "journey_ref": str,
-            "direction_ref": str,
-            "date_of_journey": str,
-            "batch_id": int,
-        }
-        keys = list(data_type.keys())
+        keys = list(avl_data_type.keys())
         data = wr.s3.read_csv(
             path=paths,
             use_threads=True,
             names=keys,
-            dtype=data_type,
+            dtype=avl_data_type,
             usecols=keys,
             header=None,
         )
@@ -197,8 +173,7 @@ class TimetableS3Client:
     def get_avl_data(self, filename: str | list[str]) -> Sequence[AVLRecord]:
         """Get AVL Data from S3 and return a list of AVLData models"""
         data = self.get_avl_data_df(filename)
-        avl_list = data.to_dict("records")
-        return [AVLRecord(r) for r in avl_list]
+        return data.to_dict("records")
 
     @timer(logger)
     def export_stop_history(

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/matching.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/matching.py
@@ -13,6 +13,12 @@ from .models import (
     RouteDetails,
     StopDetails,
     Timetable,
+    avl_group_id,
+    avl_recorded_at_time_utc,
+    stop_departure_time,
+    stop_latitude,
+    stop_longitude,
+    stop_timetable_id,
 )
 from .utils import (
     get_otp_state,
@@ -39,9 +45,9 @@ def log_specific(avl: AVLRecord, log_message: str) -> None:
     """
     if (
         "OPERATOR_REF" in os.environ
-        and os.environ["OPERATOR_REF"] == avl.operator_ref
+        and os.environ["OPERATOR_REF"] == avl["operator_ref"]
         and "LINE_NAME" in os.environ
-        and os.environ["LINE_NAME"] == avl.line_name
+        and os.environ["LINE_NAME"] == avl["line_name"]
     ):
         logger.info(log_message)
 
@@ -61,8 +67,8 @@ def haversine(avl: AVLRecord, stop: StopDetails) -> float:
 
     """
     # convert decimal degrees to radians
-    lat1, lon1 = avl.latitude, avl.longitude
-    lat2, lon2 = stop.latitude, stop.longitude
+    lat1, lon1 = avl["latitude"], avl["longitude"]
+    lat2, lon2 = stop_latitude(stop), stop_longitude(stop)
 
     lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
 
@@ -135,7 +141,7 @@ def find_potential_matches(
                     str(i): {
                         "last_avl_index": current_avl_index,
                         "last_distance": avl_next_stop_distance,
-                        "last_time_in_zone": avl.recorded_at_time_utc,
+                        "last_time_in_zone": avl_recorded_at_time_utc(avl),
                     },
                 },
             )
@@ -204,10 +210,12 @@ def check_update_first_stop(
             )
             log_specific(
                 avl,
-                f"time diff = {avl.recorded_at_time_utc - ms_last_match_time}, {avl.recorded_at_time_utc}, {ms_last_match_time}, {avl.recorded_at_time_utc - ms_last_match_time < timedelta(minutes=5)}",
+                f"time diff = {avl_recorded_at_time_utc(avl) - ms_last_match_time}, {avl_recorded_at_time_utc(avl)}, {ms_last_match_time}, {avl_recorded_at_time_utc(avl) - ms_last_match_time < timedelta(minutes=5)}",
             )
             # 8. if avl is within 5 mins after the last first stop matching time
-            if (avl.recorded_at_time_utc - ms_last_match_time) < timedelta(minutes=5):
+            if (avl_recorded_at_time_utc(avl) - ms_last_match_time) < timedelta(
+                minutes=5,
+            ):
                 log_specific(
                     avl,
                     "8. Last match time is witin 5 mins after recorded at time",
@@ -220,7 +228,7 @@ def check_update_first_stop(
                         ms_index: {
                             "last_avl_index": current_avl_index,
                             "last_distance": avl_ms_distance,
-                            "last_time_in_zone": avl.recorded_at_time_utc,
+                            "last_time_in_zone": avl_recorded_at_time_utc(avl),
                         },
                     },
                 )
@@ -231,8 +239,8 @@ def check_update_first_stop(
                 # 10. remove db matched details
                 stop_pos_distances_remove.append(
                     {
-                        "timetable_id": matched_stop_details.timetable_id,
-                        "group_id": avl.group_id,
+                        "timetable_id": stop_timetable_id(matched_stop_details),
+                        "group_id": avl_group_id(avl),
                     },
                 )
 
@@ -421,10 +429,9 @@ def write_matched_stop_to_db(
     is_final_stop: bool,  # noqa: FBT001 - boolean argument is fine for now
     route_details: RouteDetails,
     stop_pos_distances: list[RecordToAdd],
-    group_id: str,
+    avl: AVLRecord,
     pm_index: str,
     last_time_in_zone: datetime,
-    batch_id: int,
 ) -> None:
     """
     Update stop_pos_distances with the newly matched stop which will be written to the database
@@ -434,24 +441,23 @@ def write_matched_stop_to_db(
         is_final_stop (bool): Current stop is a final stop
         route_details (RouteDetails): Route stop info
         stop_pos_distances (list): The matched records that is going to be written into the database
-        group_id (str): Group id
+        avl (AVLRecord): The avl that caused the match
         pm_index (str): Potential match stop index which has become a match
         last_time_in_zone (datetime): Potential match last time in zone
-        batch_id (int): Avl batch id
 
     """
-    timetable_departure_time = route_details[pm_index].timetable_departure_time
+    timetable_departure_time = stop_departure_time(route_details[pm_index])
     time_difference = get_time_difference(last_time_in_zone, timetable_departure_time)
 
     # 23. update db with potential match details
     stop_pos_distances.append(
         {
-            "group_id": group_id,
+            "group_id": avl_group_id(avl),
             "stop_index": pm_index,
             "time_difference": time_difference,
             "last_time_in_zone_str": str(last_time_in_zone.strftime("%H:%M:%S")),
-            "timetable_id": route_details[pm_index].timetable_id,
-            "batch_id": batch_id,
+            "timetable_id": stop_timetable_id(route_details[pm_index]),
+            "batch_id": avl["batch_id"],
             "last_time_in_zone": last_time_in_zone,
             "otp_state": get_otp_state(is_final_stop, time_difference),
             "stop_type": "final" if is_final_stop else "Non-final",
@@ -505,7 +511,7 @@ def update_potential_match_with_recorded_at_time(
         avl_pm_distance (float): The distance between the avl record and the stop
 
     """
-    pm_details["last_time_in_zone"] = avl.recorded_at_time_utc
+    pm_details["last_time_in_zone"] = avl_recorded_at_time_utc(avl)
     update_potential_match_without_recorded_at_time(
         avl,
         pm_index,
@@ -667,13 +673,13 @@ def move_potential_match_to_match(
                     stop_details = route_details.get(index)
                     if not stop_details:
                         logger.warning(
-                            f"index {index} doesn't exists in timetable, group_id: {avl.group_id}",
+                            f"index {index} doesn't exists in timetable, group_id: {avl_group_id(avl)}",
                         )
                         continue
                     stop_pos_distances_remove.append(
                         {
-                            "timetable_id": stop_details.timetable_id,
-                            "group_id": avl.group_id,
+                            "timetable_id": stop_timetable_id(stop_details),
+                            "group_id": (avl_group_id(avl)),
                         },
                     )
     if not delete_potential_match:
@@ -689,10 +695,9 @@ def move_potential_match_to_match(
             is_final_stop,
             route_details,
             stop_pos_distances,
-            avl.group_id,
+            avl,
             pm_index,
             last_time_in_zone,
-            avl.batch_id,
         )
 
 
@@ -721,24 +726,24 @@ def positions_timetable_lookup(
     stop_pos_distances_remove: list[RecordToRemove] = []
     for avl in avl_dict:
         # 1. check if group id exists in timetable
-        if avl.group_id in timetable:
-            log_specific(avl, f"group_id {avl.group_id} in timetable")
+        if avl_group_id(avl) in timetable:
+            log_specific(avl, f"group_id {avl_group_id(avl)} in timetable")
 
             # 2. check if group id exists in stop_history, if not, create a blank group stop history
-            group_stop_history = get_group_stop_history(avl.group_id, stop_history)
+            group_stop_history = get_group_stop_history(avl_group_id(avl), stop_history)
             current_avl_index = group_stop_history.get("last_avl_index")
-            route_details = timetable[avl.group_id]
+            route_details = timetable[avl_group_id(avl)]
             final_stop_index = len(route_details)
             last_avl_time = group_stop_history.get("last_avl_time")
             # 3. check if current recorded_at_time is the same as the last avl time in group_stop_history
-            if last_avl_time == "" or avl.recorded_at_time_utc != validate_date(
+            if last_avl_time == "" or avl_recorded_at_time_utc(avl) != validate_date(
                 last_avl_time,
             ):
                 # 4. increment last avl index by 1 and update the time
                 current_avl_index += 1
                 group_stop_history["last_avl_index"] = current_avl_index
                 # update last avl time
-                group_stop_history["last_avl_time"] = avl.recorded_at_time_utc
+                group_stop_history["last_avl_time"] = avl_recorded_at_time_utc(avl)
                 log_specific(avl, f"avl index {current_avl_index}")
                 if len(group_stop_history["matched_stops"]) > 0:
                     # 6-10. Check if the bus is revisiting stop 1

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/models.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/models.py
@@ -2,88 +2,64 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Literal, TypedDict
 
-from attr import dataclass
-
 from .utils import validate_date
 
-
-@dataclass
-class StopDetails:
-    """Represents a stop within a timetabled route"""
-
-    latitude: float
-    longitude: float
-    expected_time: str
-    timetable_id: int
-    date: str
-
-    @property
-    def timetable_departure_time(self) -> datetime:
-        """Datetime of the expected stop departure"""
-        return validate_date(f"{self.date} {self.expected_time}")
-
-
+StopDetails = tuple[tuple[float, float], str, int, str]
 RouteDetails = Mapping[str, StopDetails]
 Timetable = Mapping[str, RouteDetails]
 OperatorShards = Mapping[str, Sequence[str]]
 
 
-class AVLRecord:
-    """Wrapper class with convenience methods for an AVL"""
+def stop_latitude(stop: StopDetails) -> float:
+    return stop[0][0]
 
-    def __init__(self, data: Mapping) -> None:
-        """Construct an AVL record given a dict record from a CSV"""
-        self._data = data
 
-    @property
-    def group_id(self) -> str:
-        """The group_id of the avl record with | as separator"""
-        return f"{self.operator_ref}|{self.line_name}|{self.journey_ref}|{self.date_of_journey}".lower()
+def stop_longitude(stop: StopDetails) -> float:
+    return stop[0][1]
 
-    @property
-    def date_of_journey(self) -> str:
-        """The date of the journey for this avl"""
-        return str(self._data["date_of_journey"])
 
-    @property
-    def journey_ref(self) -> str:
-        """The journey reference of the avl"""
-        return self._data["journey_ref"]
+def stop_expected_time(stop: StopDetails) -> str:
+    return stop[1]
 
-    @property
-    def operator_ref(self) -> str:
-        """The operator reference of the avl"""
-        return self._data["operator_ref"]
 
-    @property
-    def line_name(self) -> str:
-        """The line name of the avl"""
-        return self._data["line_name"]
+def stop_timetable_id(stop: StopDetails) -> int:
+    return stop[2]
 
-    @property
-    def latitude(self) -> float:
-        """The latitude of the avl"""
-        return float(self._data["latitude"])
 
-    @property
-    def longitude(self) -> float:
-        """The longitude of the avl"""
-        return float(self._data["longitude"])
+def stop_date(stop: StopDetails) -> str:
+    return stop[3]
 
-    @property
-    def recorded_at_time_utc(self) -> datetime:
-        """The recorded at time"""
-        return validate_date(self._data["recorded_at_time"][:19])
 
-    @property
-    def recorded_at_time_utc_str(self) -> str:
-        """The recorded at time as a string"""
-        return datetime.strftime(self.recorded_at_time_utc, "%Y-%m-%dT%H:%M:%S")
+def stop_departure_time(stop: StopDetails) -> datetime:
+    """Datetime of the expected stop departure"""
+    return validate_date(f"{stop_date(stop)} {stop_expected_time(stop)}")
 
-    @property
-    def batch_id(self) -> int:
-        """The batch_id"""
-        return self._data["batch_id"]
+
+class AVLRecord(TypedDict):
+    """AVL record"""
+
+    recorded_at_time: str
+    response_timestamp: str
+    latitude: float
+    longitude: float
+    line_name: str
+    operator_ref: str
+    vehicle_ref: str
+    journey_ref: str
+    direction_ref: str
+    date_of_journey: str
+    batch_id: int
+
+
+avl_data_type = AVLRecord.__annotations__
+
+
+def avl_group_id(avl: AVLRecord) -> str:
+    return f'{avl["operator_ref"]}|{avl["line_name"]}|{avl["journey_ref"]}|{avl["date_of_journey"]}'.lower()
+
+
+def avl_recorded_at_time_utc(avl: AVLRecord) -> datetime:
+    return validate_date(avl["recorded_at_time"][:19])
 
 
 class RecordToRemove(TypedDict):

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/utils.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/matcher/utils.py
@@ -112,11 +112,11 @@ def filter_avl_list(
             x for id_no, operators in sharded_operators.items() for x in operators
         ]
         return [
-            avl for avl in avl_list if avl.operator_ref not in all_sharded_operators
+            avl for avl in avl_list if avl["operator_ref"] not in all_sharded_operators
         ]
 
     return [
         avl
         for avl in avl_list
-        if avl.operator_ref in sharded_operators.get(shard_identifier, [])
+        if avl["operator_ref"] in sharded_operators.get(shard_identifier, [])
     ]

--- a/ingestion_pipelines/tests/sirivm_otp_matching_function/data/expected/TLCT37812152024_08_20.py
+++ b/ingestion_pipelines/tests/sirivm_otp_matching_function/data/expected/TLCT37812152024_08_20.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime  # noqa: N999 - BODS-7131
 
 expected_set = [
     {
-        "batch_id": "812384",
+        "batch_id": 812384,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 28, 22, tzinfo=UTC),
         "last_time_in_zone_str": "11:28:22",
@@ -13,7 +13,7 @@ expected_set = [
         "timetable_id": 893823336,
     },
     {
-        "batch_id": "812398",
+        "batch_id": 812398,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 30, 50, tzinfo=UTC),
         "last_time_in_zone_str": "11:30:50",
@@ -24,7 +24,7 @@ expected_set = [
         "timetable_id": 893822951,
     },
     {
-        "batch_id": "812404",
+        "batch_id": 812404,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 31, 53, tzinfo=UTC),
         "last_time_in_zone_str": "11:31:53",
@@ -35,7 +35,7 @@ expected_set = [
         "timetable_id": 893823358,
     },
     {
-        "batch_id": "812406",
+        "batch_id": 812406,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 32, 20, tzinfo=UTC),
         "last_time_in_zone_str": "11:32:20",
@@ -46,7 +46,7 @@ expected_set = [
         "timetable_id": 893822544,
     },
     {
-        "batch_id": "812408",
+        "batch_id": 812408,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 32, 50, tzinfo=UTC),
         "last_time_in_zone_str": "11:32:50",
@@ -57,7 +57,7 @@ expected_set = [
         "timetable_id": 893822533,
     },
     {
-        "batch_id": "812420",
+        "batch_id": 812420,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 34, 42, tzinfo=UTC),
         "last_time_in_zone_str": "11:34:42",
@@ -68,7 +68,7 @@ expected_set = [
         "timetable_id": 893822511,
     },
     {
-        "batch_id": "812423",
+        "batch_id": 812423,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 35, 25, tzinfo=UTC),
         "last_time_in_zone_str": "11:35:25",
@@ -79,7 +79,7 @@ expected_set = [
         "timetable_id": 893823017,
     },
     {
-        "batch_id": "812423",
+        "batch_id": 812423,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 35, 25, tzinfo=UTC),
         "last_time_in_zone_str": "11:35:25",
@@ -90,7 +90,7 @@ expected_set = [
         "timetable_id": 893823182,
     },
     {
-        "batch_id": "812428",
+        "batch_id": 812428,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 36, 14, tzinfo=UTC),
         "last_time_in_zone_str": "11:36:14",
@@ -101,7 +101,7 @@ expected_set = [
         "timetable_id": 893823149,
     },
     {
-        "batch_id": "812431",
+        "batch_id": 812431,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 36, 47, tzinfo=UTC),
         "last_time_in_zone_str": "11:36:47",
@@ -112,7 +112,7 @@ expected_set = [
         "timetable_id": 893823193,
     },
     {
-        "batch_id": "812436",
+        "batch_id": 812436,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 36, 55, tzinfo=UTC),
         "last_time_in_zone_str": "11:36:55",
@@ -123,7 +123,7 @@ expected_set = [
         "timetable_id": 893823281,
     },
     {
-        "batch_id": "812439",
+        "batch_id": 812439,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 37, 37, tzinfo=UTC),
         "last_time_in_zone_str": "11:37:37",
@@ -134,7 +134,7 @@ expected_set = [
         "timetable_id": 893823303,
     },
     {
-        "batch_id": "812439",
+        "batch_id": 812439,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 37, 37, tzinfo=UTC),
         "last_time_in_zone_str": "11:37:37",
@@ -145,7 +145,7 @@ expected_set = [
         "timetable_id": 893823094,
     },
     {
-        "batch_id": "812445",
+        "batch_id": 812445,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 38, 47, tzinfo=UTC),
         "last_time_in_zone_str": "11:38:47",
@@ -156,7 +156,7 @@ expected_set = [
         "timetable_id": 893823039,
     },
     {
-        "batch_id": "812448",
+        "batch_id": 812448,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 39, 20, tzinfo=UTC),
         "last_time_in_zone_str": "11:39:20",
@@ -167,7 +167,7 @@ expected_set = [
         "timetable_id": 893823325,
     },
     {
-        "batch_id": "812458",
+        "batch_id": 812458,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 40, 46, tzinfo=UTC),
         "last_time_in_zone_str": "11:40:46",
@@ -178,7 +178,7 @@ expected_set = [
         "timetable_id": 893823072,
     },
     {
-        "batch_id": "812470",
+        "batch_id": 812470,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 41, 52, tzinfo=UTC),
         "last_time_in_zone_str": "11:41:52",
@@ -189,7 +189,7 @@ expected_set = [
         "timetable_id": 893822467,
     },
     {
-        "batch_id": "812472",
+        "batch_id": 812472,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 43, 8, tzinfo=UTC),
         "last_time_in_zone_str": "11:43:08",
@@ -200,7 +200,7 @@ expected_set = [
         "timetable_id": 893822489,
     },
     {
-        "batch_id": "812472",
+        "batch_id": 812472,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 43, 8, tzinfo=UTC),
         "last_time_in_zone_str": "11:43:08",
@@ -211,7 +211,7 @@ expected_set = [
         "timetable_id": 893823171,
     },
     {
-        "batch_id": "812473",
+        "batch_id": 812473,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 43, 44, tzinfo=UTC),
         "last_time_in_zone_str": "11:43:44",
@@ -222,7 +222,7 @@ expected_set = [
         "timetable_id": 893823127,
     },
     {
-        "batch_id": "812479",
+        "batch_id": 812479,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 44, 34, tzinfo=UTC),
         "last_time_in_zone_str": "11:44:34",
@@ -233,7 +233,7 @@ expected_set = [
         "timetable_id": 893823116,
     },
     {
-        "batch_id": "812487",
+        "batch_id": 812487,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 46, 22, tzinfo=UTC),
         "last_time_in_zone_str": "11:46:22",
@@ -244,7 +244,7 @@ expected_set = [
         "timetable_id": 893822588,
     },
     {
-        "batch_id": "812491",
+        "batch_id": 812491,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 46, 45, tzinfo=UTC),
         "last_time_in_zone_str": "11:46:45",
@@ -255,7 +255,7 @@ expected_set = [
         "timetable_id": 893822599,
     },
     {
-        "batch_id": "812495",
+        "batch_id": 812495,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 46, 58, tzinfo=UTC),
         "last_time_in_zone_str": "11:46:58",
@@ -266,7 +266,7 @@ expected_set = [
         "timetable_id": 893822610,
     },
     {
-        "batch_id": "812496",
+        "batch_id": 812496,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 47, 30, tzinfo=UTC),
         "last_time_in_zone_str": "11:47:30",
@@ -277,7 +277,7 @@ expected_set = [
         "timetable_id": 893822874,
     },
     {
-        "batch_id": "812498",
+        "batch_id": 812498,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 48, 19, tzinfo=UTC),
         "last_time_in_zone_str": "11:48:19",
@@ -288,7 +288,7 @@ expected_set = [
         "timetable_id": 893822852,
     },
     {
-        "batch_id": "812502",
+        "batch_id": 812502,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 48, 30, tzinfo=UTC),
         "last_time_in_zone_str": "11:48:30",
@@ -299,7 +299,7 @@ expected_set = [
         "timetable_id": 893822819,
     },
     {
-        "batch_id": "812514",
+        "batch_id": 812514,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 50, 28, tzinfo=UTC),
         "last_time_in_zone_str": "11:50:28",
@@ -310,7 +310,7 @@ expected_set = [
         "timetable_id": 893822412,
     },
     {
-        "batch_id": "812520",
+        "batch_id": 812520,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 51, 35, tzinfo=UTC),
         "last_time_in_zone_str": "11:51:35",
@@ -321,7 +321,7 @@ expected_set = [
         "timetable_id": 893822423,
     },
     {
-        "batch_id": "812531",
+        "batch_id": 812531,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 53, 8, tzinfo=UTC),
         "last_time_in_zone_str": "11:53:08",
@@ -332,7 +332,7 @@ expected_set = [
         "timetable_id": 893822940,
     },
     {
-        "batch_id": "812535",
+        "batch_id": 812535,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 54, 9, tzinfo=UTC),
         "last_time_in_zone_str": "11:54:09",
@@ -343,7 +343,7 @@ expected_set = [
         "timetable_id": 893822907,
     },
     {
-        "batch_id": "812538",
+        "batch_id": 812538,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 54, 29, tzinfo=UTC),
         "last_time_in_zone_str": "11:54:29",
@@ -354,7 +354,7 @@ expected_set = [
         "timetable_id": 893822885,
     },
     {
-        "batch_id": "812549",
+        "batch_id": 812549,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 55, 53, tzinfo=UTC),
         "last_time_in_zone_str": "11:55:53",
@@ -365,7 +365,7 @@ expected_set = [
         "timetable_id": 893822775,
     },
     {
-        "batch_id": "812555",
+        "batch_id": 812555,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 57, 23, tzinfo=UTC),
         "last_time_in_zone_str": "11:57:23",
@@ -376,7 +376,7 @@ expected_set = [
         "timetable_id": 893822753,
     },
     {
-        "batch_id": "812561",
+        "batch_id": 812561,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 58, 3, tzinfo=UTC),
         "last_time_in_zone_str": "11:58:03",
@@ -387,7 +387,7 @@ expected_set = [
         "timetable_id": 893822731,
     },
     {
-        "batch_id": "812563",
+        "batch_id": 812563,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 58, 43, tzinfo=UTC),
         "last_time_in_zone_str": "11:58:43",
@@ -398,7 +398,7 @@ expected_set = [
         "timetable_id": 893822709,
     },
     {
-        "batch_id": "812566",
+        "batch_id": 812566,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 59, 5, tzinfo=UTC),
         "last_time_in_zone_str": "11:59:05",
@@ -409,7 +409,7 @@ expected_set = [
         "timetable_id": 893822698,
     },
     {
-        "batch_id": "812566",
+        "batch_id": 812566,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 59, 57, tzinfo=UTC),
         "last_time_in_zone_str": "11:59:57",
@@ -420,7 +420,7 @@ expected_set = [
         "timetable_id": 893822665,
     },
     {
-        "batch_id": "812568",
+        "batch_id": 812568,
         "group_id": "tlct|378|1215|2024-08-20",
         "last_time_in_zone": datetime(2024, 8, 20, 11, 59, 27, tzinfo=UTC),
         "last_time_in_zone_str": "11:59:27",

--- a/ingestion_pipelines/tests/sirivm_otp_matching_function/data/get_test_data.py
+++ b/ingestion_pipelines/tests/sirivm_otp_matching_function/data/get_test_data.py
@@ -1,28 +1,29 @@
 """Helpers to Load Test Data from Files"""
 
-import csv
 import json
 from pathlib import Path
 
-from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_function.client_s3 import (
-    parse_timetable,
+import pandas as pd
+
+from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_function.matcher.models import (
+    AVLRecord,
+    Timetable,
+    avl_data_type,
 )
 
 test_data_dir = Path(__file__).parent
 
 
-def read_timetable(file_name: str) -> dict:
+def read_timetable(file_name: str) -> Timetable:
     path = test_data_dir / "timetable" / file_name
     with Path.open(path) as f:
-        timetable_json = json.load(f)
-    return parse_timetable(timetable_json)
+        return json.load(f)
 
 
-def read_avl(file_name: str) -> list:
+def read_avl(file_name: str) -> list[AVLRecord]:
     path = test_data_dir / "avl" / file_name
-    avl_reader = csv.DictReader(Path.open(path))
-    avl_list = list(avl_reader)
-    avl_dicts = []
-    for avl in avl_list:
-        avl_dicts.append([avl])  # noqa: PERF401 - BODS-7131
-    return avl_dicts
+    data = pd.read_csv(path, dtype=avl_data_type, header=0)
+    data["line_name"] = data["line_name"].fillna("")
+    data["direction_ref"] = data["direction_ref"].fillna("")
+
+    return data.to_dict("records")

--- a/ingestion_pipelines/tests/sirivm_otp_matching_function/test_filter_avl_list.py
+++ b/ingestion_pipelines/tests/sirivm_otp_matching_function/test_filter_avl_list.py
@@ -1,6 +1,3 @@
-from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_function.matcher.models import (
-    AVLRecord,
-)
 from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_function.matcher.utils import (
     filter_avl_list,
 )
@@ -16,9 +13,9 @@ def test_first_shard():
         "3": ["BNSM"],
     }
     avl_list = [
-        AVLRecord({"operator_ref": shard_1_operator_id}),
-        AVLRecord({"operator_ref": shard_2_operator_id}),
-        AVLRecord({"operator_ref": "TEST"}),
+        {"operator_ref": shard_1_operator_id},
+        {"operator_ref": shard_2_operator_id},
+        {"operator_ref": "TEST"},
     ]
     assert filter_avl_list("1", shards, avl_list) == [avl_list[0]]
 
@@ -30,9 +27,9 @@ def test_no_shard():
         "3": ["BNSM"],
     }
     avl_list = [
-        AVLRecord({"operator_ref": shard_1_operator_id}),
-        AVLRecord({"operator_ref": shard_2_operator_id}),
-        AVLRecord({"operator_ref": "TEST"}),
+        {"operator_ref": shard_1_operator_id},
+        {"operator_ref": shard_2_operator_id},
+        {"operator_ref": "TEST"},
     ]
     assert filter_avl_list("0", shards, avl_list) == [avl_list[2]]
 
@@ -44,8 +41,8 @@ def test_unknown_shard():
         "3": ["BNSM"],
     }
     avl_list = [
-        AVLRecord({"operator_ref": shard_1_operator_id}),
-        AVLRecord({"operator_ref": shard_2_operator_id}),
-        AVLRecord({"operator_ref": "TEST"}),
+        {"operator_ref": shard_1_operator_id},
+        {"operator_ref": shard_2_operator_id},
+        {"operator_ref": "TEST"},
     ]
     assert filter_avl_list("4", shards, avl_list) == []

--- a/ingestion_pipelines/tests/sirivm_otp_matching_function/test_matching.py
+++ b/ingestion_pipelines/tests/sirivm_otp_matching_function/test_matching.py
@@ -18,14 +18,17 @@ from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_functi
 )
 from ingestion_pipelines.sirivm_otp_matching_function.sirivm_otp_matching_function.matcher.models import (
     AVLRecord,
+    avl_group_id,
+    avl_recorded_at_time_utc,
+    stop_departure_time,
 )
 
 from .data.get_test_data import read_avl, read_timetable
 
 
 class TestCheckUpdateFirstStop:  # noqa: D101 - BODS-7131
-    avl_record = AVLRecord(read_avl("check_update_first_stop.csv")[1][0])
-    avl_record_5_mins = AVLRecord(read_avl("check_update_first_stop.csv")[0][0])
+    avl_record = read_avl("check_update_first_stop.csv")[1]
+    avl_record_5_mins = read_avl("check_update_first_stop.csv")[0]
     timetable = read_timetable("TLCT37812152024-08-20.json")
     group_id = "tlct|378|1215|2024-08-20"
     stop_pos_distances_remove_5_mins = []  # noqa: RUF012 - BODS-7131
@@ -50,7 +53,7 @@ class TestCheckUpdateFirstStop:  # noqa: D101 - BODS-7131
         "1": {
             "last_avl_index": 8,
             "last_distance": 37.35876375439114,
-            "last_time_in_zone": avl_record_5_mins.recorded_at_time_utc,
+            "last_time_in_zone": avl_recorded_at_time_utc(avl_record_5_mins),
         },
         "2": {
             "last_avl_index": 6,
@@ -149,7 +152,7 @@ class TestCheckUpdateFirstStop:  # noqa: D101 - BODS-7131
     ):
         check_update_first_stop(
             rec,
-            timetable_dict[rec.group_id],
+            timetable_dict[avl_group_id(rec)],
             group_stop_history,
             stop_pos_distances_remove,
             current_avl_index,
@@ -160,12 +163,12 @@ class TestCheckUpdateFirstStop:  # noqa: D101 - BODS-7131
 
 
 class TestFindMatchesInPotentialMatches:  # noqa: D101 - BODS-7131
-    avl_record = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[73][0])
-    avl_record_2 = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[220][0])
-    avl_record_3 = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[222][0])
-    avl_record_4 = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[183][0])
-    avl_record_5 = AVLRecord(read_avl("FSMR3507042024-08-21.csv")[0][0])
-    avl_record_6 = AVLRecord(read_avl("FSMR3507042024-08-21.csv")[101][0])
+    avl_record = read_avl("TLCT37812152024-08-20.csv")[73]
+    avl_record_2 = read_avl("TLCT37812152024-08-20.csv")[220]
+    avl_record_3 = read_avl("TLCT37812152024-08-20.csv")[222]
+    avl_record_4 = read_avl("TLCT37812152024-08-20.csv")[183]
+    avl_record_5 = read_avl("FSMR3507042024-08-21.csv")[0]
+    avl_record_6 = read_avl("FSMR3507042024-08-21.csv")[101]
     timetable = read_timetable("TLCT37812152024-08-20.json")
     timetable_5 = read_timetable("FSMR3507042024-08-21.json")
     group_id = "tlct|378|1215|2024-08-20"
@@ -709,7 +712,7 @@ class TestFindMatchesInPotentialMatches:  # noqa: D101 - BODS-7131
     ):
         find_matches_in_potential_matches(
             avl,
-            timetable_dict[avl.group_id],
+            timetable_dict[avl_group_id(avl)],
             group_stop_history,
             current_avl_index,
             stop_pos_distances,
@@ -758,7 +761,7 @@ class TestRemoveMatchedStops:  # noqa: D101 - BODS-7131
 
 
 class TestUpdateMatchedStop:  # noqa: D101 - BODS-7131
-    avl_record = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[0][0])
+    avl_record = read_avl("TLCT37812152024-08-20.csv")[0]
     pm_index = "1"
     last_time_in_zone = datetime(2024, 9, 1, 11, 32, 5)  # noqa: DTZ001 - BODS-7131
     group_stop_history = {  # noqa: RUF012 - BODS-7131
@@ -810,7 +813,11 @@ class TestWriteMatchedStopToDb:  # noqa: D101 - BODS-7131
     timetable = read_timetable("TLCT37812152024-08-20.json")
     stop_pos_distances_non_final = []  # noqa: RUF012 - BODS-7131
     stop_pos_distances_final = []  # noqa: RUF012 - BODS-7131
-    group_id = "tlct|378|1215|2024-08-20"
+    operator_ref = "TLCT"
+    line_name = "378"
+    journey_ref = "1215"
+    date_of_journey = "2024-08-20"
+    group_id = f"{operator_ref}|{line_name}|{journey_ref}|{date_of_journey}".lower()
     batch_id = 123
     last_time_in_zone_non_final = datetime(2024, 8, 20, 11, 9, 5, tzinfo=UTC)
     last_time_in_zone_final = datetime(2024, 8, 20, 11, 35, 0, tzinfo=UTC)
@@ -820,10 +827,8 @@ class TestWriteMatchedStopToDb:  # noqa: D101 - BODS-7131
             "is_final_stop",
             "timetable_dict",
             "stop_pos_distances",
-            "group_id",
             "pm_index",
             "last_time_in_zone",
-            "batch_id",
             "expected_stop_pos_distances",
         ),
         [
@@ -831,10 +836,8 @@ class TestWriteMatchedStopToDb:  # noqa: D101 - BODS-7131
                 False,
                 timetable,
                 stop_pos_distances_non_final,
-                group_id,
                 "1",
                 last_time_in_zone_non_final,
-                batch_id,
                 [
                     {
                         "group_id": group_id,
@@ -854,10 +857,8 @@ class TestWriteMatchedStopToDb:  # noqa: D101 - BODS-7131
                 True,
                 timetable,
                 stop_pos_distances_final,
-                group_id,
                 "45",
                 last_time_in_zone_final,
-                batch_id,
                 [
                     {
                         "group_id": group_id,
@@ -880,20 +881,24 @@ class TestWriteMatchedStopToDb:  # noqa: D101 - BODS-7131
         is_final_stop: bool,  # noqa: FBT001 - BODS-7131
         timetable_dict: dict,
         stop_pos_distances: list,
-        group_id: str,
         pm_index: str,
         last_time_in_zone: datetime,
-        batch_id: int,
         expected_stop_pos_distances: list,  # noqa: ANN401 - BODS-7131
     ):
+        avl = {
+            "operator_ref": self.operator_ref,
+            "line_name": self.line_name,
+            "journey_ref": self.journey_ref,
+            "date_of_journey": self.date_of_journey,
+            "batch_id": self.batch_id,
+        }
         write_matched_stop_to_db(
             is_final_stop,
-            timetable_dict[group_id],
+            timetable_dict[self.group_id],
             stop_pos_distances,
-            group_id,
+            avl,
             pm_index,
             last_time_in_zone,
-            batch_id,
         )
         assert stop_pos_distances == expected_stop_pos_distances
 
@@ -907,14 +912,14 @@ class TestGetTimetableDepartureTime:  # noqa: D101 - BODS-7131
         details = self.timetable[self.group_id]
         expected_timtable_departure_time = datetime(2024, 8, 20, 11, 16, 0, tzinfo=UTC)
         assert (
-            details[self.pm_index].timetable_departure_time
+            stop_departure_time(details[self.pm_index])
             == expected_timtable_departure_time
         )
 
 
 class TestUpdatePotentialMatch:  # noqa: D101 - BODS-7131
-    avl_record = AVLRecord(read_avl("update_potential_match.csv")[0][0])
-    avl_record_wo_datetime = AVLRecord(read_avl("update_potential_match.csv")[1][0])
+    avl_record = read_avl("update_potential_match.csv")[0]
+    avl_record_wo_datetime = read_avl("update_potential_match.csv")[1]
     pm_index = "1"
     current_avl_index = 4
     expected_pm_details_w_datetime = {  # noqa: RUF012 - BODS-7131
@@ -1053,7 +1058,7 @@ class TestSelectPotentialMatchWithSameRecordedattime:  # noqa: D101 - BODS-7131
         },
         "matched_stops": {},
     }
-    avl_record = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[0][0])
+    avl_record = read_avl("TLCT37812152024-08-20.csv")[0]
 
     def mockenv(**envvars):  # noqa: ANN003, D102 - BODS-7131
         return mock.patch.dict(os.environ, envvars)
@@ -1136,7 +1141,7 @@ class TestSelectPotentialMatchWithSameRecordedattime:  # noqa: D101 - BODS-7131
 
 
 class TestMovePotentialMatchToMatch:  # noqa: D101 - BODS-7131
-    avl_record = AVLRecord(read_avl("TLCT37812152024-08-20.csv")[0][0])
+    avl_record = read_avl("TLCT37812152024-08-20.csv")[0]
     timetable = read_timetable("TLCT37812152024-08-20.json")
     group_id = "tlct|378|1215|2024-08-20"
     final_stop_index = "41"
@@ -1292,7 +1297,7 @@ class TestMovePotentialMatchToMatch:  # noqa: D101 - BODS-7131
                         "time_difference": 48.0,
                         "last_time_in_zone_str": "11:15:48",
                         "timetable_id": 893823336,
-                        "batch_id": avl_record.batch_id,
+                        "batch_id": avl_record["batch_id"],
                         "last_time_in_zone": datetime(
                             2024,
                             8,
@@ -1346,7 +1351,7 @@ class TestMovePotentialMatchToMatch:  # noqa: D101 - BODS-7131
                         "time_difference": 184.0,
                         "last_time_in_zone_str": "11:20:04",
                         "timetable_id": 893823358,
-                        "batch_id": avl_record.batch_id,
+                        "batch_id": avl_record["batch_id"],
                         "last_time_in_zone": datetime(
                             2024,
                             8,
@@ -1449,7 +1454,7 @@ class TestMovePotentialMatchToMatch:  # noqa: D101 - BODS-7131
                         "time_difference": 534.0,
                         "last_time_in_zone_str": "11:36:54",
                         "timetable_id": 893823138,
-                        "batch_id": avl_record.batch_id,
+                        "batch_id": avl_record["batch_id"],
                         "last_time_in_zone": datetime(
                             2024,
                             8,
@@ -1485,7 +1490,7 @@ class TestMovePotentialMatchToMatch:  # noqa: D101 - BODS-7131
     ):
         move_potential_match_to_match(
             final_stop_index,
-            timetable_dict[avl.group_id],
+            timetable_dict[avl_group_id(avl)],
             avl,
             pm_index,
             pm_details,
@@ -1507,7 +1512,7 @@ def test_positions_timetable_lookup():
         expected_stop_history,
     )
 
-    avl_list = [AVLRecord(avl[0]) for avl in read_avl("TLCT37812152024-08-20.csv")]
+    avl_list = read_avl("TLCT37812152024-08-20.csv")
     timetable = read_timetable("TLCT37812152024-08-20.json")
 
     stop_history = {}


### PR DESCRIPTION
This should have a minor performance improvement. There was an earlier conversion to data classes/wrappers, but instead of doing that work, use typed dict and helpers instead