### PR TITLE
BODS-8669 Daily export of historic matching data

### DIFF
--- a/docs/Historic Matching.md
+++ b/docs/Historic Matching.md
@@ -108,7 +108,11 @@ Use the [`generate_timetable`](../liquibase/procedures/generate_timetable.sql) p
 CALL public.generate_timetable('2024-12-04');
 ```
 
-### 2. Export Timetable CSV Data
+### 2. Export Timetable CSV Data (Optional)
+
+> [!NOTE]
+> This should not need to be done unnles you are re-generating the timetable.
+> Timetable data for a day is exported at 5pm the following day.
 
 Use the [`historic_timetable_export`](../liquibase/procedures/historic_timetable_export.sql) procedure to export timetable data to the export bucket:
 
@@ -118,7 +122,11 @@ Use the [`historic_timetable_export`](../liquibase/procedures/historic_timetable
 CALL public.historic_timetable_export('2024-12-04');
 ```
 
-### 3. Export AVL CSV Data
+### 3. Export AVL CSV Data (Optional)
+
+> [!NOTE]
+> This should not need to be done.
+> AVL data for a day is exported at 5pm the following day.
 
 Use the [`historic_avl_export`](../liquibase/procedures/historic_avl_export.sql) procedure to export AVL data for both the target date and the following day the export bucket:
 

--- a/liquibase/cron.sql
+++ b/liquibase/cron.sql
@@ -103,3 +103,9 @@ SELECT cron.schedule(
                '00 05 * * SUN', -- sundays at 05:00
                $$CALL generate_license_lines_with_dq_issues(CURRENT_DATE);$$
        );
+
+SELECT cron.schedule(
+               'export data for historic matching',
+               '30 17 * * *', -- at 17:30
+               $$CALL historic_timetable_export(CURRENT_DATE - 1);CALL historic_avl_export(CURRENT_DATE - 1);$$
+       );


### PR DESCRIPTION
Once done with matching for the day, export timetable and avl data to s3, so that it is ready when historic matching is needed