### PR TITLE
Historic Matching: Remove blocking condition

### DIFF
--- a/scripts/historic_matching.py
+++ b/scripts/historic_matching.py
@@ -541,7 +541,6 @@ def main():
             )
             if (
                 next_day not in avl_export_needed
-                and next_day not in timetable_export_needed
             ):
                 if next_day in next_day_avl_export_needed:
                     avl_export(db_password, db_host, next_day)

--- a/scripts/historic_matching.py
+++ b/scripts/historic_matching.py
@@ -532,16 +532,7 @@ def main():
         if ready_to_run and len(running_tasks) < MAX_CONCURRENT_MATCHING_TASKS:
             # Ensure that we have the avl data for the next day available before we kick off matching
             next_day = ready_to_run[0] + timedelta(days=1)
-            print(
-                {
-                    "next_day_not_in_avl_exported": next_day not in avl_export_needed,
-                    "next_day_not_in_timetable_export_needed": next_day
-                    not in timetable_export_needed,
-                }
-            )
-            if (
-                next_day not in avl_export_needed
-            ):
+            if next_day not in avl_export_needed:
                 if next_day in next_day_avl_export_needed:
                     avl_export(db_password, db_host, next_day)
                     next_day_avl_export_needed.remove(next_day)


### PR DESCRIPTION
Historic matching wasn't able to run because we have the following conditions:

- Only run matching once `timetable_export_needed` is empty
- Only run timetable_export once `ready_to_run` is empty

However after a single iteration, we append the current date to `ready_to_run` but `timetable_export_needed` still contains dates. As a result we get stuck in the while loop.

With this change, we'll start historic matching for the current date, then do the timetable export for the next date without the loop getting blocked.