### PR TITLE
SIRI SX: Add additional info to error log

### DIFF
--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -66,6 +66,8 @@ def parse_situation_element(
         if not origin_departure_str:
             logger.error(
                 "Unable to parse PTSituation element: OriginAimedDepartureTime not found",
+                situation_number=situation_number,
+                producer_ref=producer_ref,
             )
             return None
 


### PR DESCRIPTION
Add additional info to error log when OriginAimedDepartureTime not found so we can identify which situation has missing info.