### PR TITLE
Use stop id from naptan stop table in timetable generation

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.77
+version: v1.0.78

--- a/liquibase/procedures/generate_timetable.sql
+++ b/liquibase/procedures/generate_timetable.sql
@@ -807,7 +807,7 @@ begin
               journey_code,
               date_of_journey AS date_of_journey,
               departure_time,
-              stop_id,
+              b.id AS stop_id,
               ST_Y(b.location)::real lt,
               ST_X(b.location)::real AS lon,
               common_name AS stopname,


### PR DESCRIPTION
We're having an issue where the stop_id isn't populated for some service pattern stops. This PR updates timetable generation to use the stop id from the naptan_stoppoint table