### PR TITLE
Fix direction parsing sirisx

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.80
+version: v1.0.81

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -34,12 +34,12 @@ def parse_datetime(datetime_str: str) -> datetime:
 def parse_direction(direction_text: str) -> str:
     """Parse direction text to normalized string"""
     direction_map = {
-        "Inbound": "inbound",
-        "Outbound": "outbound",
-        "AntiClockwise": "antiClockwise",
-        "Clockwise": "clockwise",
+        "inbound": "inbound",
+        "outbound": "outbound",
+        "anticlockwise": "antiClockwise",
+        "clockwise": "clockwise",
     }
-    return direction_map[direction_text]
+    return direction_map[str.lower(direction_text)]
 
 
 def parse_situation_element(

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -66,7 +66,12 @@ def parse_situation_element(
         operator_noc = get_element_text(elem, ".//siri:OperatorRef")
         line_name = get_element_text(elem, ".//siri:PublishedLineName")
         direction_text = get_element_text(elem, ".//siri:DirectionRef")
-        direction = parse_direction(direction_text or "")
+        if not direction_text:
+            logger.error(
+                "Unable to parse PTSituation element: DirectionRef not found",
+            )
+            return None
+        direction = parse_direction(direction_text)
         journey_code = get_element_text(elem, ".//siri:DatedVehicleJourneyRef")
         condition = get_element_text(elem, ".//siri:Condition")
         progress = get_element_text(elem, ".//siri:Progress")

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -30,6 +30,15 @@ def parse_datetime(datetime_str: str) -> datetime:
     """Parse ISO string to datetime object"""
     return datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
 
+def parse_direction(direction_text: str) -> str:
+    """Parse direction text to normalized string"""
+    direction_map = {
+        "Inbound": "inbound",
+        "Outbound": "outbound",
+        "AntiClockwise": "antiClockwise",
+        "Clockwise": "clockwise"
+    }
+    return direction_map[direction_text]
 
 def parse_situation_element(
     elem: etree._Element,
@@ -54,7 +63,8 @@ def parse_situation_element(
 
         operator_noc = get_element_text(elem, ".//siri:OperatorRef")
         line_name = get_element_text(elem, ".//siri:PublishedLineName")
-        direction = get_element_text(elem, ".//siri:DirectionRef")
+        direction_text = get_element_text(elem, ".//siri:DirectionRef")
+        direction = parse_direction(direction_text or "")
         journey_code = get_element_text(elem, ".//siri:DatedVehicleJourneyRef")
         condition = get_element_text(elem, ".//siri:Condition")
         progress = get_element_text(elem, ".//siri:Progress")

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -30,15 +30,17 @@ def parse_datetime(datetime_str: str) -> datetime:
     """Parse ISO string to datetime object"""
     return datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
 
+
 def parse_direction(direction_text: str) -> str:
     """Parse direction text to normalized string"""
     direction_map = {
         "Inbound": "inbound",
         "Outbound": "outbound",
         "AntiClockwise": "antiClockwise",
-        "Clockwise": "clockwise"
+        "Clockwise": "clockwise",
     }
     return direction_map[direction_text]
+
 
 def parse_situation_element(
     elem: etree._Element,


### PR DESCRIPTION
When we update `expected_journeys` we join on direction. The values are normalized to `inbound`, `outbound`, `antiClockwise` and `clockwise`. Instead of trying to match these cases in SQL, we can just normalize the values before inserting them into the DB