### PR TITLE
Fix route_to_journeys table: Add date_of_journey to primary key

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.82
+version: v1.0.83

--- a/liquibase/sql/143-routes-to-journey-mapping.sql
+++ b/liquibase/sql/143-routes-to-journey-mapping.sql
@@ -1,8 +1,9 @@
 CREATE TABLE public.route_to_journeys (
-    id BIGSERIAL PRIMARY KEY,
+    id BIGSERIAL,
     group_id text NOT NULL,
     date_of_journey date NOT NULL,
     distinct_route_id integer NOT NULL
+    PRIMARY KEY (id, date_of_journey)
 ) PARTITION BY RANGE (date_of_journey);
 
 ALTER TABLE public.route_to_journeys OWNER TO abods_rw;


### PR DESCRIPTION
Deployments are failing because the primary key doesn't include the partition key.

I've tried creating the table in sandbox using the updated SQL in this PR and it works without issue