### PR TITLE
Bods 9164 new reprocessing columns

### DIFF
--- a/liquibase/db.changelog.xml
+++ b/liquibase/db.changelog.xml
@@ -464,4 +464,7 @@
     <changeSet id="147" author="abodsuser" >
         <sqlFile path="sql/147-drop-tracks-unique-constraint.sql" splitStatements="false"/>
     </changeSet>
+    <changeSet id="148" author="abodsuser" >
+        <sqlFile path="sql/148-add-reprocessing-columns.sql" splitStatements="false"/>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase/procedures/generate_timetable.sql
+++ b/liquibase/procedures/generate_timetable.sql
@@ -103,7 +103,7 @@ begin
                     inactive_at_date_prequery
                   WHERE
                         id_rank = 1
-                    AND modified <= query_date
+                    AND COALESCE(modified_before_reprocessing, modified) <= query_date
                     AND status IN (''inactive'', ''expired'')
                 ),
                 ranked_revisions AS (

--- a/liquibase/procedures/update_organisation_datasetrevision.sql
+++ b/liquibase/procedures/update_organisation_datasetrevision.sql
@@ -40,7 +40,9 @@ begin
                                                      requestor_ref,
                                                      username,
                                                      short_description,
-                                                     num_of_timing_points)
+                                                     num_of_timing_points, 
+                                                     modified_before_reprocessing,
+                                                     status_before_reprocessing)
     select id,
            created,
            modified,
@@ -70,7 +72,9 @@ begin
            requestor_ref,
            username,
            short_description,
-           num_of_timing_points
+           num_of_timing_points,
+           modified_before_reprocessing,
+           status_before_reprocessing
     from bods.organisation_datasetrevision od
     on conflict (id) do update set (
                                     created,
@@ -101,7 +105,9 @@ begin
                                     requestor_ref,
                                     username,
                                     short_description,
-                                    num_of_timing_points
+                                    num_of_timing_points,
+                                    modified_before_reprocessing,
+                                    status_before_reprocessing
                                        )= (
                                            EXCLUDED.created,
                                            EXCLUDED.modified,
@@ -130,8 +136,10 @@ begin
                                            EXCLUDED."password",
                                            EXCLUDED.requestor_ref,
                                            EXCLUDED.username,
-                                           EXCLUDED.short_description,
-                                           EXCLUDED.num_of_timing_points
+                                           EXCLUDED.short_description, 
+                                           EXCLUDED.num_of_timing_points,
+                                           EXCLUDED.modified_before_reprocessing,
+                                           EXCLUDED.status_before_reprocessing
         );
 end;
 $$;

--- a/liquibase/sql/148-add-reprocessing-columns.sql
+++ b/liquibase/sql/148-add-reprocessing-columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE organisation_datasetrevision
+ADD COLUMN modified_before_reprocessing TIMESTAMPTZ,
+ADD COLUMN status_before_reprocessing TEXT;

--- a/liquibase/sql/148-add-reprocessing-columns.sql
+++ b/liquibase/sql/148-add-reprocessing-columns.sql
@@ -1,3 +1,7 @@
+alter foreign table if exists bods.organisation_datasetrevision
+ADD COLUMN modified_before_reprocessing TIMESTAMPTZ,
+ADD COLUMN status_before_reprocessing TEXT;
+
 ALTER TABLE organisation_datasetrevision
 ADD COLUMN modified_before_reprocessing TIMESTAMPTZ,
 ADD COLUMN status_before_reprocessing TEXT;


### PR DESCRIPTION
In BODS we have added 2 new reprocessing columns, when reprocessed the modified and status of a revision are updated and the historical values are lost. The modified_before_reprocessing stores the actual date a revision was modified and therefore made inactive so we should use this where not null to understand when a revision actually became inactive