### PR TITLE
Update update_transmodel_servicepatterndistance.sql id update

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.89
+version: v1.0.90

--- a/liquibase/db.changelog.xml
+++ b/liquibase/db.changelog.xml
@@ -482,4 +482,7 @@
     <changeSet id="153" author="abodsuser" >
         <sqlFile path="sql/153-update-foreign-schema-transmodel-servicepatterndistance.sql" splitStatements="false"/>
     </changeSet>
+    <changeSet id="154" author="abodsuser" runOnChange="true" runInTransaction="true">
+        <sqlFile path="procedures/update_transmodel_servicepatterndistance.sql" splitStatements="false"/>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase/procedures/update_transmodel_servicepatterndistance.sql
+++ b/liquibase/procedures/update_transmodel_servicepatterndistance.sql
@@ -12,7 +12,7 @@ begin
            geom,
            service_pattern_id
     from bods.transmodel_servicepatterndistance ts
-    where ts.id > max_current
+    where ts.service_pattern_id > max_current
     on conflict do nothing;
 end;
 $procedure$

--- a/liquibase/procedures/update_transmodel_servicepatterndistance.sql
+++ b/liquibase/procedures/update_transmodel_servicepatterndistance.sql
@@ -8,10 +8,11 @@ begin
     insert into public.transmodel_servicepatterndistance (distance,
                                                   geom,
                                                   service_pattern_id)
-    select distance,
-           geom,
-           service_pattern_id
+    select ts.distance,
+           ts.geom,
+           ts.service_pattern_id
     from bods.transmodel_servicepatterndistance ts
+    right join public.transmodel_servicepattern tsp on tsp.id = ts.service_pattern_id
     where ts.service_pattern_id > max_current
     on conflict do nothing;
 end;


### PR DESCRIPTION
The id in servicepatterndistances update needed to be servicepattern id as the id generated in BODS is not related to that in ABODS

Right join with servicepattern is to prevent the constraint failing when there are service patterns created in bods between the servicepattern import and the servicepatterndistances import