### PR TITLE
Target partitions on matching

### DIFF
--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -63,6 +63,9 @@ class TimetableDBClient:
         with self.connection.cursor() as cursor:
             _update_batch_status(cursor, batch_id, "Failed")
 
+    def partition_name(self, date: date) -> str:
+        return f'"Timetable_p{date.strftime("%Y%m%d")}"'
+
     @timer(logger)
     def live_update_success(
         self,
@@ -72,63 +75,73 @@ class TimetableDBClient:
         process_date: date,
     ) -> None:
         """Update database to reflect successful live matching"""
+
+        # In the time after midnight, we may have matched a stop where the date_of_journey is
+        # the previous day, so we should check both partitions in the DB
+        alternate_date = process_date - timedelta(days=1)
+
         with self.connection.cursor() as cursor:
-            # In the time after midnight, we may have matched a stop where the date_of_journey is
-            # the previous day, so we should hint both values for the partition to the db
-            alternate_date = process_date - timedelta(days=1)
-            if len(entries_to_remove) > 0:
+            for target_date in [process_date, alternate_date]:
+                partition = self.partition_name(target_date)
+
+                if len(entries_to_remove) > 0:
+                    execute_values_amended(
+                        cur=cursor,
+                        sql=f"""
+                            UPDATE public.{partition} u
+                            SET time_difference = NULL,
+                                actual_departure_time = NULL,
+                                otp_state = NULL,
+                                load_time_stamp = now()::timestamp(0),
+                                timestamp_after_estimate = NULL
+                            FROM (VALUES %s) AS t(timetable_id, journey_date)
+                            WHERE u.timetable_id = t.timetable_id::bigint
+                            AND u.date_of_journey = t.journey_date::date
+                            RETURNING u.timetable_id;
+                        """,  # noqa: S608
+                        values=[
+                            (entry["timetable_id"], target_date.isoformat())
+                            for entry in entries_to_remove
+                        ],
+                    )
+
                 execute_values_amended(
                     cur=cursor,
-                    sql="""
-                        UPDATE public."Timetable" u
-                        SET time_difference = NULL,
-                            actual_departure_time = NULL,
-                            otp_state = NULL,
-                            load_time_stamp = now()::timestamp(0),
-                            timestamp_after_estimate = NULL
-                        FROM (VALUES %s) AS t(timetable_id, journey_date, alternate_journey_date)
-                        WHERE u.timetable_id = t.timetable_id::bigint
-                          AND date_of_journey IN (t.journey_date::date, t.alternate_journey_date::date)
-                        RETURNING u.timetable_id;
-                    """,
-                    values=[
-                        (
-                            entry["timetable_id"],
-                            process_date.isoformat(),
-                            alternate_date.isoformat(),
-                        )
-                        for entry in entries_to_remove
-                    ],
-                )
-
-            execute_values_amended(
-                cur=cursor,
-                sql="""
-                    UPDATE public."Timetable" u
+                    sql=f"""
+                    UPDATE public.{partition} u
                     SET time_difference = t.time_difference::int,
                         actual_departure_time = t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC',
                         timestamp_after_estimate = t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC',
                         -- When passengers aren't being picked up, we don't consider it early
-                        otp_state = CASE WHEN (u.set_down IS NOT NULL AND u.set_down AND t.otp_state = 'Early') THEN 'OnTime' ELSE t.otp_state::TEXT END,
+                        otp_state = CASE
+                            WHEN (u.set_down IS NOT NULL AND u.set_down AND t.otp_state = 'Early') THEN 'OnTime'
+                            ELSE t.otp_state::TEXT
+                        END,
                         load_time_stamp = now()::timestamp(0)
-                    FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, otp_state, timestamp_after_estimate, journey_date, alternate_journey_date)
-                    WHERE u.timetable_id = t.timetable_id::bigint
-                      AND date_of_journey IN (t.journey_date::date, t.alternate_journey_date::date)
-                    RETURNING u.timetable_id;
-                """,
-                values=[
-                    (
-                        record["timetable_id"],
-                        record["time_difference"],
-                        record["last_time_in_zone"],
-                        record["otp_state"],
-                        record["timestamp_after_estimate"],
-                        process_date.isoformat(),
-                        alternate_date.isoformat(),
+                    FROM (VALUES %s) AS t(
+                        timetable_id,
+                        time_difference,
+                        last_time_in_zone_utc,
+                        otp_state,
+                        timestamp_after_estimate,
+                        journey_date
                     )
-                    for record in entries_to_update
-                ],
-            )
+                    WHERE u.timetable_id = t.timetable_id::bigint
+                    AND u.date_of_journey = t.journey_date::date
+                    RETURNING u.timetable_id;
+                """,  # noqa: S608
+                    values=[
+                        (
+                            record["timetable_id"],
+                            record["time_difference"],
+                            record["last_time_in_zone"],
+                            record["otp_state"],
+                            record["timestamp_after_estimate"],
+                            target_date.isoformat(),
+                        )
+                        for record in entries_to_update
+                    ],
+                )
 
             _update_batch_status(cursor, batch_id, "Success")
 

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -155,70 +155,73 @@ class TimetableDBClient:
         """Update database to reflect successful historic matching"""
         if log_level:
             logger.setLevel(log_level)
+
+        alternate_date = process_date - timedelta(days=1)
+
         with self.connection.cursor() as cursor:
             # In historic matching, we know that the date we're working with is always the right,
             # but it doesn't hurt to align the code with live matching, so that we can deduplicate later
-            alternate_date = process_date - timedelta(days=1)
-            values = [
-                (
-                    record["timetable_id"],
-                    record["time_difference"],
-                    record["last_time_in_zone"],
-                    record["stop_type"],
-                    record["timestamp_after_estimate"],
-                    process_date.isoformat(),
-                    alternate_date.isoformat(),
+            for target_date in [process_date, alternate_date]:
+                partition = self.partition_name(target_date)
+                values = [
+                    (
+                        record["timetable_id"],
+                        record["time_difference"],
+                        record["last_time_in_zone"],
+                        record["stop_type"],
+                        record["timestamp_after_estimate"],
+                        target_date.isoformat(),
+                    )
+                    for record in entries_to_update
+                ]
+                execute_values_amended(
+                    cur=cursor,
+                    sql=f"""
+                        -- Recalculating time difference when it's less than zero to make sure it's calculated correctly
+                        UPDATE public.{partition} u
+                        SET time_difference          =
+                                CASE
+                                    WHEN t.time_difference::int < 0 THEN
+                                        COALESCE(
+                                                EXTRACT(epoch FROM(t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
+                                                EXTRACT(epoch FROM (t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time))
+                                        )::int
+                                    ELSE t.time_difference::int
+                                END,
+                            actual_departure_time    = t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC',
+                            timestamp_after_estimate = t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC',
+                            load_time_stamp          = now()::timestamp(0)
+                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date)
+                        WHERE u.timetable_id = t.timetable_id::bigint
+                        AND date_of_journey = t.journey_date::date
+                        RETURNING u.timetable_id;
+                    """, # noqa: S608
+                    values=values,
                 )
-                for record in entries_to_update
-            ]
-            execute_values_amended(
-                cur=cursor,
-                sql="""
-                    -- Recalculating time difference when it's less than zero to make sure it's calculated correctly
-                    UPDATE public."Timetable" u
-                    SET time_difference          =
-                            CASE
-                                WHEN t.time_difference::int < 0 THEN
-                                    COALESCE(
-                                            EXTRACT(epoch FROM(t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
-                                            EXTRACT(epoch FROM (t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time))
-                                    )::int
-                                ELSE t.time_difference::int
-                            END,
-                        actual_departure_time    = t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC',
-                        timestamp_after_estimate = t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC',
-                        load_time_stamp          = now()::timestamp(0)
-                    FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date, alternate_journey_date)
-                    WHERE u.timetable_id = t.timetable_id::bigint
-                      AND date_of_journey IN (t.journey_date::date, t.alternate_journey_date::date)
-                    RETURNING u.timetable_id;
-                """,
-                values=values,
-            )
-            # Update otp state again as the otp calculation is not taking the updated time difference value
-            execute_values_amended(
-                cur=cursor,
-                sql="""
-                    UPDATE public."Timetable" u
-                    SET otp_state = CASE
-                                        WHEN u.time_difference::int > 359 THEN 'Late'
-                                        -- If it's the final stop, we don't consider it early
-                                        WHEN (t.is_final_stop = 'Non-final'
-                                          -- When passengers aren't being picked up, we don't consider it early
-                                          AND (u.set_down IS NULL OR NOT u.set_down)
-                                          AND u.time_difference::int < -60) THEN 'Early'
-                                        ELSE 'OnTime'
-                                    END,
-                        load_time_stamp = now()::timestamp(0)
-                    FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date, alternate_journey_date)
-                    WHERE u.timetable_id = t.timetable_id::bigint
-                      AND date_of_journey IN (t.journey_date::date, t.alternate_journey_date::date)
-                      AND COALESCE (
-                                  EXTRACT(epoch FROM (t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
-                                  EXTRACT(epoch FROM (t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
-                                  0
-                          ) > -7200
-                    RETURNING u.timetable_id;
-                """,
-                values=values,
-            )
+                # Update otp state again as the otp calculation is not taking the updated time difference value
+                execute_values_amended(
+                    cur=cursor,
+                    sql=f"""
+                        UPDATE public.{partition} u
+                        SET otp_state = CASE
+                                            WHEN u.time_difference::int > 359 THEN 'Late'
+                                            -- If it's the final stop, we don't consider it early
+                                            WHEN (t.is_final_stop = 'Non-final'
+                                            -- When passengers aren't being picked up, we don't consider it early
+                                            AND (u.set_down IS NULL OR NOT u.set_down)
+                                            AND u.time_difference::int < -60) THEN 'Early'
+                                            ELSE 'OnTime'
+                                        END,
+                            load_time_stamp = now()::timestamp(0)
+                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date)
+                        WHERE u.timetable_id = t.timetable_id::bigint
+                        AND date_of_journey = t.journey_date::date
+                        AND COALESCE (
+                                    EXTRACT(epoch FROM (t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
+                                    EXTRACT(epoch FROM (t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
+                                    0
+                            ) > -7200
+                        RETURNING u.timetable_id;
+                    """, # noqa: S608
+                    values=values,
+                )

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -75,7 +75,6 @@ class TimetableDBClient:
         process_date: date,
     ) -> None:
         """Update database to reflect successful live matching"""
-
         # In the time after midnight, we may have matched a stop where the date_of_journey is
         # the previous day, so we should check both partitions in the DB
         alternate_date = process_date - timedelta(days=1)

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -93,13 +93,12 @@ class TimetableDBClient:
                                 otp_state = NULL,
                                 load_time_stamp = now()::timestamp(0),
                                 timestamp_after_estimate = NULL
-                            FROM (VALUES %s) AS t(timetable_id, journey_date)
+                            FROM (VALUES %s) AS t(timetable_id)
                             WHERE u.timetable_id = t.timetable_id::bigint
-                            AND u.date_of_journey = t.journey_date::date
                             RETURNING u.timetable_id;
                         """,  # noqa: S608
                         values=[
-                            (entry["timetable_id"], target_date.isoformat())
+                            (entry["timetable_id"],)
                             for entry in entries_to_remove
                         ],
                     )
@@ -122,11 +121,9 @@ class TimetableDBClient:
                         time_difference,
                         last_time_in_zone_utc,
                         otp_state,
-                        timestamp_after_estimate,
-                        journey_date
+                        timestamp_after_estimate
                     )
                     WHERE u.timetable_id = t.timetable_id::bigint
-                    AND u.date_of_journey = t.journey_date::date
                     RETURNING u.timetable_id;
                 """,  # noqa: S608
                     values=[
@@ -136,7 +133,6 @@ class TimetableDBClient:
                             record["last_time_in_zone"],
                             record["otp_state"],
                             record["timestamp_after_estimate"],
-                            target_date.isoformat(),
                         )
                         for record in entries_to_update
                     ],
@@ -169,7 +165,6 @@ class TimetableDBClient:
                         record["last_time_in_zone"],
                         record["stop_type"],
                         record["timestamp_after_estimate"],
-                        target_date.isoformat(),
                     )
                     for record in entries_to_update
                 ]
@@ -190,9 +185,8 @@ class TimetableDBClient:
                             actual_departure_time    = t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC',
                             timestamp_after_estimate = t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC',
                             load_time_stamp          = now()::timestamp(0)
-                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date)
+                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate)
                         WHERE u.timetable_id = t.timetable_id::bigint
-                        AND date_of_journey = t.journey_date::date
                         RETURNING u.timetable_id;
                     """,  # noqa: S608
                     values=values,
@@ -212,9 +206,8 @@ class TimetableDBClient:
                                             ELSE 'OnTime'
                                         END,
                             load_time_stamp = now()::timestamp(0)
-                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate, journey_date)
+                        FROM (VALUES %s) AS t(timetable_id, time_difference, last_time_in_zone_utc, is_final_stop, timestamp_after_estimate)
                         WHERE u.timetable_id = t.timetable_id::bigint
-                        AND date_of_journey = t.journey_date::date
                         AND COALESCE (
                                     EXTRACT(epoch FROM (t.last_time_in_zone_utc::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),
                                     EXTRACT(epoch FROM (t.timestamp_after_estimate::timestamp AT TIME ZONE 'UTC' - u.expected_departure_time)),

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -98,8 +98,7 @@ class TimetableDBClient:
                             RETURNING u.timetable_id;
                         """,  # noqa: S608
                         values=[
-                            (entry["timetable_id"],)
-                            for entry in entries_to_remove
+                            (entry["timetable_id"],) for entry in entries_to_remove
                         ],
                     )
 

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/client_db.py
@@ -194,7 +194,7 @@ class TimetableDBClient:
                         WHERE u.timetable_id = t.timetable_id::bigint
                         AND date_of_journey = t.journey_date::date
                         RETURNING u.timetable_id;
-                    """, # noqa: S608
+                    """,  # noqa: S608
                     values=values,
                 )
                 # Update otp state again as the otp calculation is not taking the updated time difference value
@@ -221,6 +221,6 @@ class TimetableDBClient:
                                     0
                             ) > -7200
                         RETURNING u.timetable_id;
-                    """, # noqa: S608
+                    """,  # noqa: S608
                     values=values,
                 )


### PR DESCRIPTION
Target specific partitions of the Timetable table when doing updates for matching. This should reduce the number of locks acquired - when we target the parent table, we end up locking all partitions. 