### PR TITLE
Bods 9407 updating avl recorded

### DIFF
--- a/liquibase/db.changelog.xml
+++ b/liquibase/db.changelog.xml
@@ -491,4 +491,7 @@
     <changeSet id="156" author="abodsuser" >
         <sqlFile path="sql/156-add-license-expected-services.sql" splitStatements="false"/>
     </changeSet>
+    <changeSet id="157" author="abodsuser" runOnChange="true" runInTransaction="true">
+        <sqlFile path="procedures/populate_avl_recorded_expected_journeys.sql" splitStatements="false"/>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase/procedures/incomplete_data_load.sql
+++ b/liquibase/procedures/incomplete_data_load.sql
@@ -230,45 +230,6 @@ BEGIN
           incomplete_data_tmp_stops_with_invalid_gps_in_zone
       )
       AND date_of_journey = partition_date;
-     
- RAISE NOTICE '% Populating avl_recorded column in expected Journeys', clock_timestamp();
-
-	UPDATE public.expected_journeys
-	SET avl_recorded = null
-	WHERE date_of_journey = partition_date;
-
-	    -- Set avl_recorded to False for journeys missing operator NOCs
-	UPDATE public.expected_journeys
-	SET avl_recorded = FALSE
-	WHERE vehicle_journey_id IN (
-	    SELECT vehiclejourney_id 
-	    FROM incomplete_data_tmp_stops_without_operator_nocs
-	)
-	AND date_of_journey = partition_date;
-	
-	-- Set avl_recorded to False for journeys missing services
-	UPDATE public.expected_journeys
-	SET avl_recorded = FALSE
-	WHERE vehicle_journey_id IN (
-	    SELECT vehiclejourney_id 
-	    FROM incomplete_data_tmp_stops_without_services
-	)
-	AND date_of_journey = partition_date;
-	
-	-- Set avl_recorded to False for journeys missing journey codes
-	UPDATE public.expected_journeys
-	SET avl_recorded = FALSE
-	WHERE vehicle_journey_id IN (
-	    SELECT vehiclejourney_id 
-	    FROM incomplete_data_tmp_stops_without_journey_codes
-	)
-	AND date_of_journey = partition_date;
-	
-	-- Set avl_recorded to True for all remaining journeys
-	UPDATE public.expected_journeys
-	SET avl_recorded = TRUE
-	WHERE avl_recorded IS NULL
-	AND date_of_journey = partition_date;
 
     RAISE NOTICE '% Dropping temp tables', clock_timestamp();
 

--- a/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
+++ b/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
@@ -6,20 +6,25 @@ AS $procedure$
 BEGIN
     RAISE NOTICE '% Start running populate_avl_recorded_expected_journeys ', clock_timestamp();
 
+    -- Step 1: Set all to TRUE
+    UPDATE public.expected_journeys
+    SET avl_recorded = TRUE
+    WHERE date_of_journey = partition_date;
+
+    -- Step 2: Set relevant ones to FALSE
     UPDATE public.expected_journeys ej
-    SET avl_recorded = CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM public."Timetable" t
-            WHERE t.group_id = ej.group_id
-              AND t.date_of_journey = partition_date
-              AND t.incomplete_reason IN (1, 2, 3)
-        ) THEN FALSE
-        ELSE TRUE
-    END
-    WHERE ej.date_of_journey = partition_date;
+    SET avl_recorded = FALSE
+    WHERE EXISTS (
+        SELECT 1
+        FROM public."Timetable" t
+        WHERE t.group_id = ej.group_id
+          AND t.date_of_journey = partition_date
+          AND t.incomplete_reason IN (1, 2, 3)
+    )
+    AND ej.date_of_journey = partition_date;
 
     RAISE NOTICE '% populate_avl_recorded_expected_journeys complete', clock_timestamp();
 END;
 $procedure$;
+
 

--- a/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
+++ b/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
@@ -22,3 +22,4 @@ BEGIN
     RAISE NOTICE '% populate_avl_recorded_expected_journeys complete', clock_timestamp();
 END;
 $procedure$;
+

--- a/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
+++ b/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
@@ -1,30 +1,24 @@
-CREATE OR REPLACE PROCEDURE public.populate_avl_recorded_expected_journeys(IN partition_date date DEFAULT (CURRENT_DATE - '1 day'::interval))
- LANGUAGE plpgsql
+CREATE OR REPLACE PROCEDURE public.populate_avl_recorded_expected_journeys(
+    IN partition_date date DEFAULT (CURRENT_DATE - '1 day'::interval)
+)
+LANGUAGE plpgsql
 AS $procedure$
 BEGIN
     RAISE NOTICE '% Start running populate_avl_recorded_expected_journeys ', clock_timestamp();
-   
-   	UPDATE public.expected_journeys
-	SET avl_recorded = null
-	WHERE date_of_journey = partition_date;
-   
-	UPDATE public.expected_journeys ej
-	SET avl_recorded = FALSE
-	WHERE EXISTS (
-	    SELECT 1
-	    FROM public."Timetable" t
-	    WHERE t.group_id = ej.group_id
-	      AND t.date_of_journey = partition_date
-	      AND t.incomplete_reason IN (1, 2, 3)
-	)
-	AND ej.date_of_journey = partition_date;
-	
-	UPDATE public.expected_journeys
-	SET avl_recorded = TRUE
-	WHERE avl_recorded IS NULL
-	AND date_of_journey = partition_date;
+
+    UPDATE public.expected_journeys ej
+    SET avl_recorded = CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM public."Timetable" t
+            WHERE t.group_id = ej.group_id
+              AND t.date_of_journey = partition_date
+              AND t.incomplete_reason IN (1, 2, 3)
+        ) THEN FALSE
+        ELSE TRUE
+    END
+    WHERE ej.date_of_journey = partition_date;
 
     RAISE NOTICE '% populate_avl_recorded_expected_journeys complete', clock_timestamp();
 END;
-$procedure$
-;
+$procedure$;

--- a/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
+++ b/liquibase/procedures/populate_avl_recorded_expected_journeys.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE PROCEDURE public.populate_avl_recorded_expected_journeys(IN partition_date date DEFAULT (CURRENT_DATE - '1 day'::interval))
+ LANGUAGE plpgsql
+AS $procedure$
+BEGIN
+    RAISE NOTICE '% Start running populate_avl_recorded_expected_journeys ', clock_timestamp();
+   
+   	UPDATE public.expected_journeys
+	SET avl_recorded = null
+	WHERE date_of_journey = partition_date;
+   
+	UPDATE public.expected_journeys ej
+	SET avl_recorded = FALSE
+	WHERE EXISTS (
+	    SELECT 1
+	    FROM public."Timetable" t
+	    WHERE t.group_id = ej.group_id
+	      AND t.date_of_journey = partition_date
+	      AND t.incomplete_reason IN (1, 2, 3)
+	)
+	AND ej.date_of_journey = partition_date;
+	
+	UPDATE public.expected_journeys
+	SET avl_recorded = TRUE
+	WHERE avl_recorded IS NULL
+	AND date_of_journey = partition_date;
+
+    RAISE NOTICE '% populate_avl_recorded_expected_journeys complete', clock_timestamp();
+END;
+$procedure$
+;


### PR DESCRIPTION
Populating the avl_recorded column has been separated from the incomplete data load to improve historical reprocessing time (1 minute vs 15 minutes), reduce complexity and isolate the function in case of issues