### PR TITLE
Fix/bods 9687 cancellations import to use prod endpoint

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.97
+version: v1.0.98

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from io import BytesIO
 from os import environ
+import time
 
 import requests
 from aws_lambda_powertools import Logger
@@ -14,7 +15,7 @@ siri_sx_cancellations_url = environ.get("SIRI_SX_CANCELLATIONS_URL")
 NS_URI = "http://www.siri.org.uk/siri"
 
 logger = Logger()
-conn = setup_db()
+#conn = setup_db()
 
 
 def get_element_text(
@@ -166,7 +167,25 @@ def parse_xml(xml_bytes: bytes) -> list[SituationRecord]:
     return rows
 
 
+def ensure_db_connection(retry_count: int = 3):
+    for attempt in range(retry_count):
+        try:
+            if conn.closed:
+                logger.info("Database connection closed, reconnecting... (attempt %d)", attempt + 1)
+                conn = setup_db()
+            return
+        except AttributeError:
+            logger.info("Database connection not initialized, reconnecting... (attempt %d)", attempt + 1)
+        except Exception as e:
+            logger.error(f"Database connection error: {e}. Retrying... (attempt {attempt + 1})")
+        time.sleep(1)
+    # Final check after retries
+    if getattr(conn, 'closed', True):
+        raise RuntimeError("Failed to establish database connection after retries.")
+
 def insert_rows(rows: list[SituationRecord]) -> None:
+#   ensure_db_connection()
+    conn = setup_db()
     with conn.cursor() as cur:
         logger.info("Inserting journey event rows", count=len(rows))
         insert_stmt = """
@@ -222,3 +241,4 @@ def lambda_handler(_event: dict, _context: dict) -> None:
     logger.info(
         "All rows parsed and inserted",
     )
+    

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -17,6 +17,7 @@ siri_sx_cancellations_url = environ.get("SIRI_SX_CANCELLATIONS_URL")
 NS_URI = "http://www.siri.org.uk/siri"
 
 logger = Logger()
+conn = setup_db()
 
 
 def get_element_text(
@@ -240,7 +241,6 @@ def insert_rows(cur: cursor, rows: list[SituationRecord]) -> None:
 
 
 def lambda_handler(_event: dict, _context: dict) -> None:
-    conn = setup_db()
     ensure_db_connection(conn)
     logger.info("Retrieving XML from SIRI SX")
     response = requests.get(siri_sx_cancellations_url, timeout=30)

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -1,11 +1,13 @@
+import time
 from datetime import UTC, datetime
 from io import BytesIO
 from os import environ
-import time
 
+import psycopg2
 import requests
 from aws_lambda_powertools import Logger
 from lxml import etree
+from psycopg2.extensions import cursor
 from psycopg2.extras import execute_batch
 
 from .models import SituationRecord
@@ -15,7 +17,6 @@ siri_sx_cancellations_url = environ.get("SIRI_SX_CANCELLATIONS_URL")
 NS_URI = "http://www.siri.org.uk/siri"
 
 logger = Logger()
-#conn = setup_db()
 
 
 def get_element_text(
@@ -167,68 +168,80 @@ def parse_xml(xml_bytes: bytes) -> list[SituationRecord]:
     return rows
 
 
-def ensure_db_connection(retry_count: int = 3):
+def ensure_db_connection(
+    conn: psycopg2.extensions.connection,
+    retry_count: int = 3,
+) -> None:
     for attempt in range(retry_count):
         try:
-            if conn.closed:
-                logger.info("Database connection closed, reconnecting... (attempt %d)", attempt + 1)
+            if conn is None or conn.closed:
+                logger.info(
+                    "Database connection closed, reconnecting... (attempt %d)",
+                    attempt + 1,
+                )
                 conn = setup_db()
-            return
+            else:
+                return
         except AttributeError:
-            logger.info("Database connection not initialized, reconnecting... (attempt %d)", attempt + 1)
-        except Exception as e:
-            logger.error(f"Database connection error: {e}. Retrying... (attempt {attempt + 1})")
+            logger.info(
+                "Database connection not initialized, reconnecting... (attempt %d)",
+                attempt + 1,
+            )
+        except Exception:
+            logger.exception(
+                f"Database connection error - Retrying... (attempt {attempt + 1})",
+            )
         time.sleep(1)
     # Final check after retries
-    if getattr(conn, 'closed', True):
+    if getattr(conn, "closed", True):
         raise RuntimeError("Failed to establish database connection after retries.")
 
-def insert_rows(rows: list[SituationRecord]) -> None:
-#   ensure_db_connection()
-    conn = setup_db()
-    with conn.cursor() as cur:
-        logger.info("Inserting journey event rows", count=len(rows))
-        insert_stmt = """
-            INSERT INTO public.siri_sx_situations (
-                producer_ref,
-                situation_number,
-                version,
-                operator_noc,
-                line_name,
-                direction,
-                date_of_journey,
-                origin_departure_time,
-                validity_start_date,
-                validity_end_date,
-                journey_code,
-                condition,
-                progress,
-                event_timestamp,
-                creation_time
-            )
-            VALUES (
-                %(producer_ref)s,
-                %(situation_number)s,
-                %(version)s,
-                %(operator_noc)s,
-                %(line_name)s,
-                %(direction)s,
-                %(date_of_journey)s,
-                %(origin_departure_time)s,
-                %(validity_start_date)s,
-                %(validity_end_date)s,
-                %(journey_code)s,
-                %(condition)s,
-                %(progress)s,
-                %(event_timestamp)s,
-                %(creation_time)s
-            )
-            ON CONFLICT (producer_ref, situation_number, version) DO NOTHING;
-        """
-        execute_batch(cur, insert_stmt, [row.to_dict() for row in rows], page_size=1000)
+
+def insert_rows(cur: cursor, rows: list[SituationRecord]) -> None:
+    logger.info("Inserting journey event rows", count=len(rows))
+    insert_stmt = """
+        INSERT INTO public.siri_sx_situations (
+            producer_ref,
+            situation_number,
+            version,
+            operator_noc,
+            line_name,
+            direction,
+            date_of_journey,
+            origin_departure_time,
+            validity_start_date,
+            validity_end_date,
+            journey_code,
+            condition,
+            progress,
+            event_timestamp,
+            creation_time
+        )
+        VALUES (
+            %(producer_ref)s,
+            %(situation_number)s,
+            %(version)s,
+            %(operator_noc)s,
+            %(line_name)s,
+            %(direction)s,
+            %(date_of_journey)s,
+            %(origin_departure_time)s,
+            %(validity_start_date)s,
+            %(validity_end_date)s,
+            %(journey_code)s,
+            %(condition)s,
+            %(progress)s,
+            %(event_timestamp)s,
+            %(creation_time)s
+        )
+        ON CONFLICT (producer_ref, situation_number, version) DO NOTHING;
+    """
+    execute_batch(cur, insert_stmt, [row.to_dict() for row in rows], page_size=1000)
 
 
 def lambda_handler(_event: dict, _context: dict) -> None:
+    conn = setup_db()
+    ensure_db_connection(conn)
     logger.info("Retrieving XML from SIRI SX")
     response = requests.get(siri_sx_cancellations_url, timeout=30)
     response.raise_for_status()
@@ -237,7 +250,8 @@ def lambda_handler(_event: dict, _context: dict) -> None:
     if not rows:
         logger.warning("No rows to insert.")
         return
-    insert_rows(rows)
+    with conn.cursor() as cur:
+        insert_rows(cur, rows)
     logger.info(
         "All rows parsed and inserted",
     )

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/app.py
@@ -241,4 +241,3 @@ def lambda_handler(_event: dict, _context: dict) -> None:
     logger.info(
         "All rows parsed and inserted",
     )
-    

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/test_app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/test_app.py
@@ -43,6 +43,12 @@ def situation_record() -> SituationRecord:
 
 
 @patch(
+    "ingestion_pipelines.sirisx_situations_import_function.sirisx_situations_import_function.app.ensure_db_connection",
+)
+@patch(
+    "ingestion_pipelines.sirisx_situations_import_function.sirisx_situations_import_function.app.conn",
+)
+@patch(
     "ingestion_pipelines.sirisx_situations_import_function.sirisx_situations_import_function.app.insert_rows",
 )
 @patch(
@@ -55,9 +61,15 @@ def test_lambda_handler(
     mock_get: MagicMock,
     mock_parse_xml: MagicMock,
     mock_insert_rows: MagicMock,
+    mock_conn: MagicMock,
+    mock_ensure_db_connection: MagicMock,
     situation_record: SituationRecord,
 ) -> None:
     from .app import lambda_handler  # noqa: PLC0415,I001
+
+    mock_ensure_db_connection.return_value= None
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
     # Mock response from requests.get
     mock_response = MagicMock()
@@ -73,7 +85,7 @@ def test_lambda_handler(
     # Check expected calls
     mock_get.assert_called_once()
     mock_parse_xml.assert_called_once_with(b"<siri-xs-xml>")
-    mock_insert_rows.assert_called_once_with([situation_record])
+    mock_insert_rows.assert_called_once_with(mock_cursor, [situation_record])
 
 
 def test_parse_xml() -> None:
@@ -179,7 +191,7 @@ def test_insert_rows(
     mock_cursor = MagicMock()
     mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-    insert_rows([situation_record])
+    insert_rows(mock_conn, [situation_record])
 
     mock_execute_batch.assert_called_once()
     args, _ = mock_execute_batch.call_args

--- a/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/test_app.py
+++ b/ingestion_pipelines/sirisx_situations_import_function/sirisx_situations_import_function/test_app.py
@@ -67,7 +67,7 @@ def test_lambda_handler(
 ) -> None:
     from .app import lambda_handler  # noqa: PLC0415,I001
 
-    mock_ensure_db_connection.return_value= None
+    mock_ensure_db_connection.return_value = None
     mock_cursor = MagicMock()
     mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 


### PR DESCRIPTION
This pull request introduces changes to improve the reliability of database connection handling in the `sirisx_situations_import_function` pipeline. The main focus is on ensuring that the database connection is properly established and reconnected when necessary, which helps prevent failures during data ingestion.

**Database connection reliability improvements:**

* Added a new `ensure_db_connection` function that attempts to reconnect to the database if the connection is closed or not initialized, with retries and logging for better error handling.
* Commented out the global initialization of `conn` to avoid potential stale connections and moved connection setup inside the `insert_rows` function for more reliable usage.

**General codebase updates:**

* Imported the `time` module to support retry logic in database connection management.