### PR TITLE
update distance import

### DIFF
--- a/liquibase/db.changelog.xml
+++ b/liquibase/db.changelog.xml
@@ -509,4 +509,7 @@
     <changeSet id="162" author="abodsuser" runOnChange="true" runInTransaction="true">
         <sqlFile path="procedures/flag_cancelled_expected_journeys.sql" splitStatements="false"/>
     </changeSet>
+    <changeSet id="163" author="abodsuser">
+        <sqlFile path="sql/163-fix-servicepatterndistance.sql" splitStatements="false"/>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase/procedures/update_transmodel_servicepatterndistance.sql
+++ b/liquibase/procedures/update_transmodel_servicepatterndistance.sql
@@ -7,12 +7,13 @@ declare
 begin
     insert into public.transmodel_servicepatterndistance (distance,
                                                   geom,
-                                                  service_pattern_id)
+                                                  service_pattern_id,
+                                                  coord_track_distance)
     select ts.distance,
            ts.geom,
-           ts.service_pattern_id
+           ts.service_pattern_id,
+           ts.coord_track_distance
     from bods.transmodel_servicepatterndistance ts
-    right join public.transmodel_servicepattern tsp on tsp.id = ts.service_pattern_id
     where ts.service_pattern_id > max_current
     on conflict do nothing;
 end;

--- a/liquibase/sql/163-fix-servicepatterndistance.sql
+++ b/liquibase/sql/163-fix-servicepatterndistance.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.transmodel_servicepatterndistance
+DROP CONSTRAINT IF EXISTS fk_service_pattern;
+
+alter foreign table if exists bods.transmodel_servicepatterndistance
+ADD COLUMN coord_track_distance INT4;
+
+ALTER TABLE transmodel_servicepatterndistance
+ADD COLUMN coord_track_distance INT4;


### PR DESCRIPTION
This pull request introduces a migration to fix and extend the `transmodel_servicepatterndistance` table and related procedures. The main focus is on adding the `coord_track_distance` column and ensuring the schema and data handling are consistent.

**Database schema changes:**

* Added a new column `coord_track_distance` of type `INT4` to both the `public.transmodel_servicepatterndistance` table and the foreign table `bods.transmodel_servicepatterndistance`.
* Dropped the `fk_service_pattern` constraint from `public.transmodel_servicepatterndistance` if it exists, likely to avoid conflicts with the new column addition.

**Data migration and procedure updates:**

* Updated the procedure `update_transmodel_servicepatterndistance.sql` to insert the new `coord_track_distance` column when migrating data from `bods.transmodel_servicepatterndistance` to `public.transmodel_servicepatterndistance`.

**Changelog updates:**

* Added a new Liquibase changeset (`id="163"`) to execute the schema changes in `163-fix-servicepatterndistance.sql`.