### PR TITLE
Feature/remove stagecoach from cancellations

### DIFF
--- a/liquibase/procedures/flag_cancelled_expected_journeys.sql
+++ b/liquibase/procedures/flag_cancelled_expected_journeys.sql
@@ -30,7 +30,10 @@ begin
     AND ej.line_name = latest_situation.line_name
     AND ej.journey_code = latest_situation.journey_code
     AND ej.direction = latest_situation.direction
-    AND latest_situation.condition != 'normalService'; -- # Cancelled service
+    AND latest_situation.condition != 'normalService' -- # Cancelled service
+    AND ej.operator_noc NOT IN (
+        SELECT noc FROM bods.organisation_operatorcode WHERE organisation_id = 15
+    );
     
 
     RAISE NOTICE '% flag_cancelled_expected_journeys complete', clock_timestamp();

--- a/liquibase/procedures/flag_cancelled_expected_journeys.sql
+++ b/liquibase/procedures/flag_cancelled_expected_journeys.sql
@@ -32,7 +32,7 @@ begin
     AND ej.direction = latest_situation.direction
     AND latest_situation.condition != 'normalService' -- # Cancelled service
     AND ej.operator_noc NOT IN (
-        SELECT noc FROM bods.organisation_operatorcode WHERE organisation_id = 15
+        SELECT noc FROM bods.organisation_operatorcode WHERE organisation_id = 15 --remove stagecoach, can remove once uat
     );
     
 


### PR DESCRIPTION
This pull request makes a targeted change to the `flag_cancelled_expected_journeys.sql` procedure to refine which journeys are flagged as cancelled. The update adds an exclusion for journeys operated by a specific organization, improving the accuracy of the cancellation logic.

**Business logic refinement:**

* Updated the cancellation flagging condition to exclude journeys operated by organizations with `organisation_id = 15` (currently Stagecoach), by adding a `NOT IN` clause on `ej.operator_noc`. This ensures that cancellations for these operators are not flagged, as part of a temporary measure for UAT.