### PR TITLE
Adding coord distance when updating distance

### DIFF
--- a/liquibase/procedures/update_expected_service_distances.sql
+++ b/liquibase/procedures/update_expected_service_distances.sql
@@ -33,8 +33,8 @@ BEGIN
             ss.service_pattern_id,
             ss.noc_and_line_and_servicecode,
             ss.total_count,
-            ss.total_count * sd.distance AS total_distance, 
-            ss.avl_true_count * sd.distance AS avl_true_distance
+            ss.total_count * COALESCE(sd.coord_track_distance, sd.distance) AS total_distance, 
+            ss.avl_true_count * COALESCE(sd.coord_track_distance, sd.distance) AS avl_true_distance
         FROM 
             service_summary ss
         JOIN 


### PR DESCRIPTION
This pull request makes a targeted change to the calculation of service distances in the `update_expected_service_distances.sql` procedure. The update ensures that, when available, the more precise `coord_track_distance` is used instead of the generic `distance` value.

Calculation logic improvement:

* Updated the computation of `total_distance` and `avl_true_distance` to use `COALESCE(sd.coord_track_distance, sd.distance)`, preferring `coord_track_distance` when present.