### PR TITLE
DBODS-1377: add status-update unit tests for S3, OTP, and DB ingestion conditional queries

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.1.03
+version: v1.1.04

--- a/ingestion_pipelines/sirivm_db_ingestion_function/sirivm_db_ingestion_function/test_app.py
+++ b/ingestion_pipelines/sirivm_db_ingestion_function/sirivm_db_ingestion_function/test_app.py
@@ -96,3 +96,85 @@ def test_lambda_handler_error(
         ANY,
         "test-key",
     )
+
+
+@pytest.mark.parametrize(
+    ("status", "start_time", "end_time", "key", "expected_params"),
+    [
+        (
+            "Inprogress",
+            "2026-04-28T10:00:00",
+            None,
+            "test-key",
+            [
+                "Inprogress",
+                "2026-04-28T10:00:00",
+                None,
+                "test-key",
+                "batch123",
+                "Inprogress",
+                "2026-04-28T10:00:00",
+                None,
+                "test-key",
+            ],
+        ),
+        (
+            "Success",
+            "2026-04-28T10:00:00",
+            "2026-04-28T10:05:00",
+            "test-key",
+            [
+                "Success",
+                "2026-04-28T10:00:00",
+                "2026-04-28T10:05:00",
+                "test-key",
+                "batch123",
+                "Success",
+                "2026-04-28T10:00:00",
+                "2026-04-28T10:05:00",
+                "test-key",
+            ],
+        ),
+        (
+            "Failed",
+            "2026-04-28T10:00:00",
+            "2026-04-28T10:05:00",
+            "test-key",
+            [
+                "Failed",
+                "2026-04-28T10:00:00",
+                "2026-04-28T10:05:00",
+                "test-key",
+                "batch123",
+                "Failed",
+                "2026-04-28T10:00:00",
+                "2026-04-28T10:05:00",
+                "test-key",
+            ],
+        ),
+    ],
+)
+def test_update_batch_status_uses_conditional_update(
+    status: str,
+    start_time: str,
+    end_time: str | None,
+    key: str,
+    expected_params: list[object],
+) -> None:
+    from .app import update_batch_status  # noqa: PLC0415,I001
+
+    mock_cursor = MagicMock()
+    update_batch_status(
+        mock_cursor,
+        "batch123",
+        status,
+        start_time,
+        end_time,
+        key,
+    )
+
+    sql, params = mock_cursor.execute.call_args[0]
+
+    assert "WHERE batch_id = %s" in sql
+    assert "IS DISTINCT FROM" in sql
+    assert params == expected_params

--- a/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/test_client_db.py
+++ b/ingestion_pipelines/sirivm_otp_matching_function/sirivm_otp_matching_function/test_client_db.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_aws_region(monkeypatch) -> None:  # noqa: ANN001 type not exported
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
+
+
+@pytest.mark.parametrize("status", ["Success", "Failed"])
+def test_update_batch_status_uses_conditional_update(status: str) -> None:
+    from .client_db import _update_batch_status  # noqa: PLC0415,I001
+
+    mock_cursor = MagicMock()
+    _update_batch_status(mock_cursor, 123, status)
+
+    sql, params = mock_cursor.execute.call_args[0]
+
+    assert "WHERE batch_id = %s" in sql
+    assert "otp_update_status IS DISTINCT FROM %s" in sql
+    assert params == [status, 123, status]

--- a/ingestion_pipelines/sirivm_s3_ingestion_function/sirivm_s3_ingestion_function/test_app_status_update.py
+++ b/ingestion_pipelines/sirivm_s3_ingestion_function/sirivm_s3_ingestion_function/test_app_status_update.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_aws_region(monkeypatch) -> None:  # noqa: ANN001 type not exported
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
+
+
+@pytest.mark.parametrize(
+    ("status", "end_time", "key", "expected_params"),
+    [
+        (
+            "Success",
+            "2026-04-28 10:00:00.000000",
+            "incoming-key",
+            [
+                "Success",
+                "2026-04-28 10:00:00.000000",
+                "incoming-key",
+                123,
+                "Success",
+                "2026-04-28 10:00:00.000000",
+                "incoming-key",
+                "incoming-key",
+            ],
+        ),
+        (
+            "Failed",
+            "2026-04-28 10:05:00.000000",
+            "incoming-key",
+            [
+                "Failed",
+                "2026-04-28 10:05:00.000000",
+                "incoming-key",
+                123,
+                "Failed",
+                "2026-04-28 10:05:00.000000",
+                "incoming-key",
+                "incoming-key",
+            ],
+        ),
+        (
+            "Failed",
+            "2026-04-28 10:05:00.000000",
+            None,
+            [
+                "Failed",
+                "2026-04-28 10:05:00.000000",
+                None,
+                123,
+                "Failed",
+                "2026-04-28 10:05:00.000000",
+                None,
+                None,
+            ],
+        ),
+    ],
+)
+def test_update_s3_ingestion_status_uses_conditional_update(
+    status: str,
+    end_time: str,
+    key: str | None,
+    expected_params: list[object],
+) -> None:
+    from .app import update_s3_ingestion_status  # noqa: PLC0415,I001
+
+    mock_cursor = MagicMock()
+    update_s3_ingestion_status(
+        mock_cursor,
+        123,
+        status,
+        end_time,
+        key,
+    )
+
+    sql, params = mock_cursor.execute.call_args[0]
+
+    assert "WHERE batch_id = %s" in sql
+    assert "IS DISTINCT FROM" in sql
+    assert "COALESCE(%s, s3_avl_gip_key)" in sql
+    assert params == expected_params


### PR DESCRIPTION
* S3: test covers success, failed with a key, and failed with no key - confirms that updates only run when values have changed and that an existing key is preserved when no key is provided.

* OTP: test covers success and failed states - confirms that the query uses a conditional update and does not perform unnecessary writes when the status is already the same.

* DB: test covers in-progress, success, and failed states - confirms that conditional predicates are applied and that the full parameter list is passed in the expected order.