### PR TITLE
feat(parameters): add NOC parameters for S3 ingestion function

### DIFF
--- a/ingestion_pipelines/samconfig.yaml
+++ b/ingestion_pipelines/samconfig.yaml
@@ -47,7 +47,7 @@ sandbox:
         Environment='sandbox'
         VpcId='/abods/sandbox/vpc/id'
         VpcSubnets='/abods/sandbox/vpc/subnets/private'
-        NocRoleArn='arn:aws:iam::390403896175:role/bods-1297-data-landing-zone-cross-account-role'
+        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
 
 dev:
   deploy:
@@ -60,6 +60,7 @@ dev:
         Environment='dev'
         VpcId='/abods/dev/vpc/id'
         VpcSubnets='/abods/dev/vpc/subnets/private'
+        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
 
 test:
   deploy:
@@ -72,6 +73,7 @@ test:
         Environment='test'
         VpcId='/abods/test/vpc/id'
         VpcSubnets='/abods/test/vpc/subnets/private'
+        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
 
 uat:
   deploy:

--- a/ingestion_pipelines/samconfig.yaml
+++ b/ingestion_pipelines/samconfig.yaml
@@ -47,6 +47,7 @@ sandbox:
         Environment='sandbox'
         VpcId='/abods/sandbox/vpc/id'
         VpcSubnets='/abods/sandbox/vpc/subnets/private'
+        NocRoleArn='arn:aws:iam::390403896175:role/bods-1297-data-landing-zone-cross-account-role'
 
 dev:
   deploy:

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -38,7 +38,7 @@ Parameters:
     Type: String
     Default: 'bods-1297-data-landing-zone'
   NocRoleArn:
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
     Default: ''
   BucketRegion:
     Type: String

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -34,6 +34,18 @@ Parameters:
   VpcSubnets:
     Type: AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>
     Default: ''
+  NocBucket:
+    Type: String
+    Default: 'bods-1297-data-landing-zone'
+  NocRoleArn:
+    Type: String
+    Default: 'arn:aws:iam::390403896175:role/bods-1297-data-landing-zone-cross-account-role'
+  BucketRegion:
+    Type: String
+    Default: 'eu-west-2'
+  NocS3Key:
+    Type: String
+    Default: 'raw/noc'
   VersioningConfiguration:
     Type: String
     Default: 'Suspended'
@@ -435,6 +447,10 @@ Resources:
           POSTGRES_PORT: !Ref RdsDbPort
           POSTGRES_DB: !Sub '{{resolve:ssm:/${ProjectName}/${Environment}/rds/dbname}}'
           POSTGRES_USER: !Sub '${ProjectName}_proxy_rw'
+          NOC_BUCKET: !Ref NocBucket
+          NOC_ROLE_ARN: !Ref NocRoleArn
+          BUCKET_REGION: !Ref BucketRegion
+          NOC_S3_KEY: !Ref NocS3Key
       LoggingConfig:
         LogGroup: !Ref TravelineDbIngestionFunctionLogGroup
 

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -39,7 +39,7 @@ Parameters:
     Default: 'bods-1297-data-landing-zone'
   NocRoleArn:
     Type: String
-    Default: 'arn:aws:iam::390403896175:role/bods-1297-data-landing-zone-cross-account-role'
+    Default: ''
   BucketRegion:
     Type: String
     Default: 'eu-west-2'


### PR DESCRIPTION
This PR adds environment variables to TravelineDbIngestionFunction to support the NOC read process.

NOC_BUCKET: 
NOC_ROLE_ARN: 
BUCKET_REGION: 
NOC_S3_KEY:

https://busopendataservice.atlassian.net/browse/DBODS-1626?focusedCommentId=91322