### PR TITLE
Dbods 1626/lambda env noc read process support:  Update NocRoleArn references to new value in SAM configuration

### DIFF
--- a/ingestion_pipelines/samconfig.yaml
+++ b/ingestion_pipelines/samconfig.yaml
@@ -47,7 +47,7 @@ sandbox:
         Environment='sandbox'
         VpcId='/abods/sandbox/vpc/id'
         VpcSubnets='/abods/sandbox/vpc/subnets/private'
-        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
+        NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn'
 
 dev:
   deploy:
@@ -60,7 +60,7 @@ dev:
         Environment='dev'
         VpcId='/abods/dev/vpc/id'
         VpcSubnets='/abods/dev/vpc/subnets/private'
-        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
+        NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn'
 
 test:
   deploy:
@@ -73,7 +73,7 @@ test:
         Environment='test'
         VpcId='/abods/test/vpc/id'
         VpcSubnets='/abods/test/vpc/subnets/private'
-        NocRoleArn='/abods/shared/data-landing-zone-role-arn'
+        NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn'
 
 uat:
   deploy:
@@ -86,6 +86,7 @@ uat:
         Environment='uat'
         VpcId='/abods/uat/vpc/id'
         VpcSubnets='/abods/uat/vpc/subnets/private'
+        NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn'
 
 prod:
   sync:
@@ -101,5 +102,6 @@ prod:
         Environment='prod'
         VpcId='/abods/prod/vpc/id'
         VpcSubnets='/abods/prod/vpc/subnets/private'
+        NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn'
         VersioningConfiguration='Enabled'
         BackupEnabled='true'

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -454,7 +454,7 @@ Resources:
           POSTGRES_DB: !Sub '{{resolve:ssm:/${ProjectName}/${Environment}/rds/dbname}}'
           POSTGRES_USER: !Sub '${ProjectName}_proxy_rw'
           NOC_BUCKET: !Ref NocBucket
-          NOC_ROLE_ARN: !Ref NocRoleArn
+          NOC_ROLE_ARN: !Sub '{{resolve:ssm:/abods/shared/data-landing-zone-role-arn}}'
           BUCKET_REGION: !Ref BucketRegion
           NOC_S3_KEY: !Ref NocS3Key
       LoggingConfig:

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -426,7 +426,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'ssm:GetParameter'
-            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/abods/shared/data-landing-zone-role-arn'
+            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${NocRoleArn}'
       Events:
         TravelineSchedule:
           Type: Schedule
@@ -454,7 +454,7 @@ Resources:
           POSTGRES_DB: !Sub '{{resolve:ssm:/${ProjectName}/${Environment}/rds/dbname}}'
           POSTGRES_USER: !Sub '${ProjectName}_proxy_rw'
           NOC_BUCKET: !Ref NocBucket
-          NOC_ROLE_ARN: !Sub '{{resolve:ssm:/abods/shared/data-landing-zone-role-arn}}'
+          NOC_ROLE_ARN: !Sub '{{resolve:ssm:${NocRoleArn}}}'
           BUCKET_REGION: !Ref BucketRegion
           NOC_S3_KEY: !Ref NocS3Key
       LoggingConfig:

--- a/ingestion_pipelines/template.yaml
+++ b/ingestion_pipelines/template.yaml
@@ -38,8 +38,8 @@ Parameters:
     Type: String
     Default: 'bods-1297-data-landing-zone'
   NocRoleArn:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: '/abods/shared/data-landing-zone-role-arn'
+    Type: String
+    Default: ''
   BucketRegion:
     Type: String
     Default: 'eu-west-2'
@@ -421,6 +421,12 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: !GetAtt TravelineDbIngestionFunctionLogGroup.Arn
+        - Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - 'ssm:GetParameter'
+            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/abods/shared/data-landing-zone-role-arn'
       Events:
         TravelineSchedule:
           Type: Schedule


### PR DESCRIPTION
- Updated abods-itm/ingestion_pipelines/template.yaml to use a new plain-string SSM parameter path for NOC_ROLE_ARN
- Updated IAM ssm:GetParameter resource to reference the dynamic NocRoleArn path
- Updated abods-itm/ingestion_pipelines/samconfig.yaml to pass NocRoleArn='/abods/shared/bods-data-landing-zone-role-arn' 